### PR TITLE
[pybindings] remove linking to libpython

### DIFF
--- a/cmake/BundledBoost.cmake
+++ b/cmake/BundledBoost.cmake
@@ -57,7 +57,6 @@ function(setup_bundled_boost_with_python)
 
   include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
-  set(PYTHON_LIBRARIES ${PYTHON_LIBRARIES} PARENT_SCOPE)
   set(Boost_LIBRARIES ${Boost_LIBRARIES} PARENT_SCOPE)
 
   add_subdirectory(pyhelpers)

--- a/generator/mwm_diff/pymwm_diff/CMakeLists.txt
+++ b/generator/mwm_diff/pymwm_diff/CMakeLists.txt
@@ -18,7 +18,6 @@ omim_link_libraries(
   coding
   base
   stats_client
-  ${PYTHON_LIBRARIES}
   ${Boost_LIBRARIES}
   ${LIBZ}
 )

--- a/generator/pygen/CMakeLists.txt
+++ b/generator/pygen/CMakeLists.txt
@@ -44,7 +44,6 @@ omim_link_libraries(
   sqlite3
   ${CMAKE_DL_LIBS}
   ${LIBZ}
-  ${PYTHON_LIBRARIES}
   ${Boost_LIBRARIES}
 )
 

--- a/kml/pykmlib/CMakeLists.txt
+++ b/kml/pykmlib/CMakeLists.txt
@@ -11,7 +11,6 @@ omim_add_library(${PROJECT_NAME} MODULE ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  ${PYTHON_LIBRARIES}
   ${Boost_LIBRARIES}
   kml
   indexer

--- a/local_ads/pylocal_ads/CMakeLists.txt
+++ b/local_ads/pylocal_ads/CMakeLists.txt
@@ -11,7 +11,6 @@ omim_add_library(${PROJECT_NAME} MODULE ${SRC})
 
 omim_link_libraries(
   ${PROJECT_NAME}
-  ${PYTHON_LIBRARIES}
   ${Boost_LIBRARIES}
   local_ads
   base

--- a/pyhelpers/setup.py
+++ b/pyhelpers/setup.py
@@ -138,25 +138,6 @@ BOOST_LIBRARYDIR = os.path.join(BOOST_ROOT, 'stage', 'lib')
 ORIGINAL_CWD = os.getcwd()
 
 
-def python_static_libdir():
-    return get_config_var('LIBPL')
-
-
-def python_ld_library():
-    LDLIBRARY = get_config_var('LDLIBRARY')
-    PYTHONFRAMEWORKPREFIX = get_config_var('PYTHONFRAMEWORKPREFIX')
-    LIBDIR = get_config_var('LIBDIR')
-    LIBPL = get_config_var('LIBPL')
-    candidates = [
-        os.path.join(PYTHONFRAMEWORKPREFIX, LDLIBRARY),
-        os.path.join(LIBDIR, LDLIBRARY),
-        os.path.join(LIBPL, LDLIBRARY),
-    ]
-    for candidate in candidates:
-        if os.path.exists(candidate):
-            return candidate
-
-
 @contextmanager
 def chdir(target_dir):
     saved_cwd = os.getcwd()
@@ -310,11 +291,10 @@ class BuildBoostPythonCommand(Command, object):
         mkpath(self.omim_builddir)
         with open(self.get_boost_config_path(), 'w') as f:
             f.write(
-                'using python : {} : {} : {} : {} ;\n'.format(
+                'using python : {} : {} : {} ;\n'.format(
                     get_python_version(),
                     sys.executable,
                     get_python_inc(),
-                    python_static_libdir(),
                 )
             )
 
@@ -404,7 +384,6 @@ class BuildOmimBindingCommand(build_ext, object):
                     '-DPYTHON_VERSION={}'.format(get_python_version()),
                     '-DPYTHON_EXECUTABLE={}'.format(sys.executable),
                     '-DPYTHON_INCLUDE_DIR={}'.format(get_python_inc()),
-                    '-DPYTHON_LIBRARY={}'.format(python_ld_library()),
                     OMIM_ROOT,
                 ]
             )

--- a/search/pysearch/CMakeLists.txt
+++ b/search/pysearch/CMakeLists.txt
@@ -32,7 +32,6 @@ omim_link_libraries(
   pugixml
   stats_client
   succinct
-  ${PYTHON_LIBRARIES}
   ${Boost_LIBRARIES}
   ${LIBZ}
 )

--- a/search/pysearch/README.txt
+++ b/search/pysearch/README.txt
@@ -27,7 +27,6 @@ This document describes how to use this module.
         -DPYBINDINGS=ON\
         -DPYTHON_VERSION=3.7\
         -DPYBINDINGS_VERSION=3.7\
-        -DPYTHON_LIBRARIES=<path-to-libpython.dylib>\
         -DPYTHON_INCLUDE_DIRS=<path-to-dir-with-Python.h>\
         -DCMAKE_PREFIX_PATH=<path-to-qt5.5>
 

--- a/tracking/pytracking/CMakeLists.txt
+++ b/tracking/pytracking/CMakeLists.txt
@@ -9,5 +9,5 @@ include_directories(${CMAKE_BINARY_DIR})
 
 omim_add_library(${PROJECT_NAME} MODULE ${SRC})
 
-omim_link_libraries(${PROJECT_NAME} ${PYTHON_LIBRARIES} ${Boost_LIBRARIES} tracking coding geometry base)
+omim_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} tracking coding geometry base)
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")

--- a/traffic/pytraffic/CMakeLists.txt
+++ b/traffic/pytraffic/CMakeLists.txt
@@ -43,7 +43,6 @@ omim_link_libraries(
   opening_hours
   succinct
   icu
-  ${PYTHON_LIBRARIES}
   ${Boost_LIBRARIES}
   ${LIBZ}
 )


### PR DESCRIPTION
В принципе, линковка с libpythonX.Y.so означает намерение создать внутри собственной программы интерпретатор питона, и начать выполнять python-код в нём.
Мы этого в наших расширениях совсем не делаем, и линковка не должна быть нужной.

Насущная причина, помимо концептуальной - это невозможность сборки `manylinux2010`-wheels. Ноги растут из pypa/manylinux#30 - там было решено, что из-за различий в дистрибутивах linux лучше просто запретить линковку расширений с libpythonX.Y.so.

В итоге, на linux всё собирается и потом работает.
Нужно ещё проверить на маке.