### PR TITLE
[base][coding] Use LRU cache for TextStorage.

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -42,6 +42,7 @@ set(
   logging.cpp
   logging.hpp
   lower_case.cpp
+  lru_cache.hpp
   macros.hpp
   math.hpp
   matrix.hpp

--- a/base/base_tests/CMakeLists.txt
+++ b/base/base_tests/CMakeLists.txt
@@ -24,7 +24,7 @@ set(
   levenshtein_dfa_test.cpp
   linked_map_tests.cpp
   logging_test.cpp
-  lru_cache_test.cpp
+  lru_cache_tests.cpp
   math_test.cpp
   matrix_test.cpp
   mem_trie_test.cpp

--- a/base/base_tests/CMakeLists.txt
+++ b/base/base_tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(
   levenshtein_dfa_test.cpp
   linked_map_tests.cpp
   logging_test.cpp
+  lru_cache_test.cpp
   math_test.cpp
   matrix_test.cpp
   mem_trie_test.cpp

--- a/base/base_tests/lru_cache_test.cpp
+++ b/base/base_tests/lru_cache_test.cpp
@@ -1,0 +1,166 @@
+#include "testing/testing.hpp"
+
+#include "base/lru_cache.hpp"
+
+#include <cstddef>
+#include <map>
+
+template <typename Key, typename Value>
+class LruCacheTest
+{
+public:
+  LruCacheTest(size_t maxCacheSize, typename LruCache<Key, Value>::Loader const & loader)
+    : m_cache(maxCacheSize, loader)
+  {
+  }
+
+  Value const & GetValue(Key const & key) { return m_cache.GetValue(key); }
+  bool IsValid() const { return m_cache.IsValid(); }
+
+private:
+  LruCache<Key, Value> m_cache;
+};
+
+template <typename Key, typename Value>
+class LruCacheKeyAgeTest
+{
+public:
+  void InsertKey(Key const & key) { m_keyAge.InsertKey(key); }
+  void UpdateAge(Key const & key) { m_keyAge.UpdateAge(key); }
+  Key const & GetLruKey() const { return m_keyAge.GetLruKey(); }
+  void RemoveLru() { m_keyAge.RemoveLru(); }
+  bool IsValid() const { return m_keyAge.IsValidForTesting(); }
+
+  size_t GetAge() const { return m_keyAge.m_age; }
+  std::map<size_t, Key> const & GetAgeToKey() const { return m_keyAge.m_ageToKey; };
+  std::map<Key, size_t> const & GetKeyToAge() const { return m_keyAge.m_keyToAge; };
+
+private:
+  typename LruCache<Key, Value>::KeyAge m_keyAge;
+};
+
+template <typename Key, typename Value>
+void TestAge(LruCacheKeyAgeTest<Key, Value> const & keyAge,
+             size_t expectedAge, std::map<size_t, Key> const & expectedAgeToKey,
+             std::map<Key, size_t> const & expectedKeyToAge)
+{
+  TEST(keyAge.IsValid(), ());
+  TEST_EQUAL(keyAge.GetAge(), expectedAge, ());
+  TEST_EQUAL(keyAge.GetAgeToKey(), expectedAgeToKey, ());
+  TEST_EQUAL(keyAge.GetKeyToAge(), expectedKeyToAge, ());
+}
+
+UNIT_TEST(LruCacheAgeTest)
+{
+  using Key = int;
+  using Value = double;
+  LruCacheKeyAgeTest<Key, Value> age;
+
+  TEST_EQUAL(age.GetAge(), 0, ());
+  TEST(age.GetAgeToKey().empty(), ());
+  TEST(age.GetKeyToAge().empty(), ());
+
+  age.InsertKey(10);
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{1 /* age */, 10 /* key */}});
+    std::map<Key, size_t> const expectedKeyToAge({{10 /* key */, 1 /* age */}});
+    TestAge(age, 1 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.InsertKey(9);
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{1, 10}, {2, 9}});
+    std::map<Key, size_t> const expectedKeyToAge({{10, 1}, {9, 2}});
+    TestAge(age, 2 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.RemoveLru();
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{2, 9}});
+    std::map<Key, size_t> const expectedKeyToAge({{9, 2}});
+    TestAge(age, 2 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.InsertKey(11);
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{2, 9}, {3, 11}});
+    std::map<Key, size_t> const expectedKeyToAge({{9, 2}, {11, 3}});
+    TestAge(age, 3 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.UpdateAge(9);
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{4, 9}, {3, 11}});
+    std::map<Key, size_t> const expectedKeyToAge({{9, 4}, {11, 3}});
+    TestAge(age, 4 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.RemoveLru();
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{4, 9}});
+    std::map<Key, size_t> const expectedKeyToAge({{9, 4}});
+    TestAge(age, 4 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+
+  age.InsertKey(12);
+  {
+    std::map<size_t, Key> const expectedAgeToKey({{4, 9}, {5, 12}});
+    std::map<Key, size_t> const expectedKeyToAge({{9, 4}, {12, 5}});
+    TestAge(age, 5 /* cache age */, expectedAgeToKey, expectedKeyToAge);
+  }
+}
+
+UNIT_TEST(LruCacheSmokeTest)
+{
+  using Key = int;
+  using Value = int;
+
+  {
+    LruCacheTest<Key, Value> cache(1 /* maxCacheSize */, [](Key k, Value & v) { v = 1; } /* loader */);
+    TEST_EQUAL(cache.GetValue(1), 1, ());
+    TEST_EQUAL(cache.GetValue(2), 1, ());
+    TEST_EQUAL(cache.GetValue(3), 1, ());
+    TEST_EQUAL(cache.GetValue(4), 1, ());
+    TEST_EQUAL(cache.GetValue(1), 1, ());
+    TEST(cache.IsValid(), ());
+  }
+
+  {
+    LruCacheTest<Key, Value> cache(3 /* maxCacheSize */, [](Key k, Value & v) { v = k; } /* loader */);
+    TEST_EQUAL(cache.GetValue(1), 1, ());
+    TEST_EQUAL(cache.GetValue(2), 2, ());
+    TEST_EQUAL(cache.GetValue(2), 2, ());
+    TEST_EQUAL(cache.GetValue(5), 5, ());
+    TEST_EQUAL(cache.GetValue(1), 1, ());
+    TEST(cache.IsValid(), ());
+  }
+}
+
+UNIT_TEST(LruCacheLoaderCallsTest)
+{
+  using Key = int;
+  using Value = int;
+  bool shouldLoadBeCalled = true;
+  auto loader = [&shouldLoadBeCalled](Key k, Value & v) {
+    TEST(shouldLoadBeCalled, ());
+    v = k;
+  };
+
+  LruCacheTest<Key, Value> cache(3 /* maxCacheSize */, loader);
+  TEST(cache.IsValid(), ());
+  cache.GetValue(1);
+  cache.GetValue(2);
+  cache.GetValue(3);
+  TEST(cache.IsValid(), ());
+  shouldLoadBeCalled = false;
+  cache.GetValue(3);
+  cache.GetValue(2);
+  cache.GetValue(1);
+  TEST(cache.IsValid(), ());
+  shouldLoadBeCalled = true;
+  cache.GetValue(4);
+  TEST(cache.IsValid(), ());
+  shouldLoadBeCalled = false;
+  cache.GetValue(1);
+  TEST(cache.IsValid(), ());
+}

--- a/base/base_tests/lru_cache_test.cpp
+++ b/base/base_tests/lru_cache_test.cpp
@@ -33,7 +33,7 @@ public:
 
   size_t GetAge() const { return m_keyAge.m_age; }
   std::map<size_t, Key> const & GetAgeToKey() const { return m_keyAge.m_ageToKey; };
-  std::map<Key, size_t> const & GetKeyToAge() const { return m_keyAge.m_keyToAge; };
+  std::unordered_map<Key, size_t> const & GetKeyToAge() const { return m_keyAge.m_keyToAge; };
 
 private:
   typename LruCache<Key, Value>::KeyAge m_keyAge;
@@ -42,7 +42,7 @@ private:
 template <typename Key, typename Value>
 void TestAge(LruCacheKeyAgeTest<Key, Value> const & keyAge,
              size_t expectedAge, std::map<size_t, Key> const & expectedAgeToKey,
-             std::map<Key, size_t> const & expectedKeyToAge)
+             std::unordered_map<Key, size_t> const & expectedKeyToAge)
 {
   TEST(keyAge.IsValid(), ());
   TEST_EQUAL(keyAge.GetAge(), expectedAge, ());
@@ -63,49 +63,49 @@ UNIT_TEST(LruCacheAgeTest)
   age.InsertKey(10);
   {
     std::map<size_t, Key> const expectedAgeToKey({{1 /* age */, 10 /* key */}});
-    std::map<Key, size_t> const expectedKeyToAge({{10 /* key */, 1 /* age */}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{10 /* key */, 1 /* age */}});
     TestAge(age, 1 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.InsertKey(9);
   {
     std::map<size_t, Key> const expectedAgeToKey({{1, 10}, {2, 9}});
-    std::map<Key, size_t> const expectedKeyToAge({{10, 1}, {9, 2}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{10, 1}, {9, 2}});
     TestAge(age, 2 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.RemoveLru();
   {
     std::map<size_t, Key> const expectedAgeToKey({{2, 9}});
-    std::map<Key, size_t> const expectedKeyToAge({{9, 2}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{9, 2}});
     TestAge(age, 2 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.InsertKey(11);
   {
     std::map<size_t, Key> const expectedAgeToKey({{2, 9}, {3, 11}});
-    std::map<Key, size_t> const expectedKeyToAge({{9, 2}, {11, 3}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{9, 2}, {11, 3}});
     TestAge(age, 3 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.UpdateAge(9);
   {
     std::map<size_t, Key> const expectedAgeToKey({{4, 9}, {3, 11}});
-    std::map<Key, size_t> const expectedKeyToAge({{9, 4}, {11, 3}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{9, 4}, {11, 3}});
     TestAge(age, 4 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.RemoveLru();
   {
     std::map<size_t, Key> const expectedAgeToKey({{4, 9}});
-    std::map<Key, size_t> const expectedKeyToAge({{9, 4}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{9, 4}});
     TestAge(age, 4 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 
   age.InsertKey(12);
   {
     std::map<size_t, Key> const expectedAgeToKey({{4, 9}, {5, 12}});
-    std::map<Key, size_t> const expectedKeyToAge({{9, 4}, {12, 5}});
+    std::unordered_map<Key, size_t> const expectedKeyToAge({{9, 4}, {12, 5}});
     TestAge(age, 5 /* cache age */, expectedAgeToKey, expectedKeyToAge);
   }
 }

--- a/base/base_tests/lru_cache_test.cpp
+++ b/base/base_tests/lru_cache_test.cpp
@@ -9,16 +9,26 @@ template <typename Key, typename Value>
 class LruCacheTest
 {
 public:
-  LruCacheTest(size_t maxCacheSize, typename LruCache<Key, Value>::Loader const & loader)
-    : m_cache(maxCacheSize, loader)
+  using Loader = std::function<void(Key const & key, Value & value)>;
+
+  LruCacheTest(size_t maxCacheSize, Loader const & loader) : m_cache(maxCacheSize), m_loader(loader)
   {
   }
 
-  Value const & GetValue(Key const & key) { return m_cache.GetValue(key); }
+  Value const & GetValue(Key const & key)
+  {
+    bool found;
+    auto & value = m_cache.Find(key, found);
+    if (!found)
+      m_loader(key, value);
+    return value;
+  }
+
   bool IsValid() const { return m_cache.IsValid(); }
 
 private:
   LruCache<Key, Value> m_cache;
+  Loader m_loader;
 };
 
 template <typename Key, typename Value>

--- a/base/base_tests/lru_cache_tests.cpp
+++ b/base/base_tests/lru_cache_tests.cpp
@@ -24,7 +24,7 @@ public:
     return value;
   }
 
-  bool IsValid() const { return m_cache.IsValid(); }
+  bool IsValid() const { return m_cache.IsValidForTesting(); }
 
 private:
   LruCache<Key, Value> m_cache;

--- a/base/lru_cache.hpp
+++ b/base/lru_cache.hpp
@@ -97,7 +97,7 @@ private:
       CHECK_EQUAL(removed, 1, ());
       // Putting new age.
       m_ageToKey[m_age] = key;
-      m_keyToAge[key] = m_age;
+      keyToAgeIt->second = m_age;
     }
 
     /// \returns Least recently used key without updating the age.
@@ -154,7 +154,7 @@ private:
   private:
     size_t m_age = 0;
     std::map<size_t, Key> m_ageToKey;
-    std::map<Key, size_t> m_keyToAge;
+    std::unordered_map<Key, size_t> m_keyToAge;
   };
 
   size_t const m_maxCacheSize;

--- a/base/lru_cache.hpp
+++ b/base/lru_cache.hpp
@@ -1,0 +1,164 @@
+#pragma once
+
+#include "base/assert.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <unordered_map>
+
+/// \brief Implementation of cache with least recently used replacement policy.
+template <typename Key, typename Value>
+class LruCache
+{
+  template <typename K, typename V> friend class LruCacheTest;
+  template <typename K, typename V> friend class LruCacheKeyAgeTest;
+public:
+  using Loader = std::function<void(Key const & key, Value & value)>;
+
+  /// \param maxCacheSize Maximum size of the cache in number of items. It should be one or greater.
+  /// \param loader Function which is called if it's necessary to load a new item for the cache.
+  /// For the same |key| should be loaded the same |value|.
+  LruCache(size_t maxCacheSize, Loader const & loader)
+    : m_maxCacheSize(maxCacheSize), m_loader(loader)
+  {
+    CHECK_GREATER(maxCacheSize, 0, ());
+  }
+
+  /// \brief Loads value, if it's necessary, by |key| with |m_loader|, puts it to |m_cache| and
+  /// returns the reference to the value to |m_cache|.
+  Value const & GetValue(Key const & key)
+  {
+    auto const it = m_cache.find(key);
+    if (it != m_cache.cend())
+    {
+      m_keyAge.UpdateAge(key);
+      return it->second;
+    }
+
+    if (m_cache.size() >= m_maxCacheSize)
+    {
+      m_cache.erase(m_keyAge.GetLruKey());
+      m_keyAge.RemoveLru();
+    }
+
+    m_keyAge.InsertKey(key);
+    Value & value = m_cache[key];
+    m_loader(key, value);
+    return value;
+  }
+
+  /// \brief Checks for coherence class params.
+  /// \note It's a time consumption method and should be called for tests only.
+  bool IsValid() const
+  {
+    if (!m_keyAge.IsValidForTesting())
+      return false;
+
+    for (auto const & kv : m_cache)
+    {
+      if (!m_keyAge.IsKeyValidForTesting(kv.first))
+        return false;
+    }
+
+    return true;
+  }
+
+private:
+  /// \brief This class support cross mapping from age to key and for key to age.
+  /// It lets effectively get least recently used key (key with minimum value of age)
+  /// and find key age by its value to update the key age.
+  /// \note Size of |m_ageToKey| and |m_ageToKey| should be the sameß.
+  /// All keys of |m_ageToKey| should be values of |m_ageToKey| and on the contrary
+  /// all keys of |m_ageToKey| should be values of |m_ageToKey|.
+  /// \note Ages should be unique for all keys.
+  class KeyAge
+  {
+    template <typename K, typename V> friend class LruCacheKeyAgeTest;
+  public:
+    /// \brief Increments |m_age| and insert key to |m_ageToKey| and |m_keyToAge|.
+    /// \note This method should be used only if there's no |key| in |m_ageToKey| and |m_keyToAge|.
+    void InsertKey(Key const & key)
+    {
+      ++m_age;
+      m_ageToKey[m_age] = key;
+      m_keyToAge[key] = m_age;
+    }
+
+    /// \brief Increments |m_age| and updates key age in |m_ageToKey| and |m_keyToAge|.
+    /// \note This method should be used only if there's |key| in |m_ageToKey| and |m_keyToAge|.
+    void UpdateAge(Key const & key)
+    {
+      ++m_age;
+      auto keyToAgeIt = m_keyToAge.find(key);
+      CHECK(keyToAgeIt != m_keyToAge.end(), ());
+      // Removing former age.
+      size_t const removed = m_ageToKey.erase(keyToAgeIt->second);
+      CHECK_EQUAL(removed, 1, ());
+      // Putting new age.
+      m_ageToKey[m_age] = key;
+      m_keyToAge[key] = m_age;
+    }
+
+    /// \returns Least recently used key without updating the age.
+    /// \note |m_ageToKey| and |m_keyToAge| shouldn't be empty.
+    Key const & GetLruKey() const
+    {
+      CHECK(!m_ageToKey.empty(), ());
+      // The smaller age the older item.
+      return m_ageToKey.cbegin()->second;
+    }
+
+    void RemoveLru()
+    {
+      Key const & lru = GetLruKey();
+      size_t const removed = m_keyToAge.erase(lru);
+      CHECK_EQUAL(removed, 1, ());
+      m_ageToKey.erase(m_ageToKey.begin());
+    }
+
+    /// \brief Checks for coherence class params.
+    /// \note It's a time consumption method and should be called for tests only.
+    bool IsValidForTesting() const
+    {
+      for (auto const & kv : m_ageToKey)
+      {
+        if (kv.first > m_age)
+          return false;
+        if (m_keyToAge.find(kv.second) == m_keyToAge.cend())
+          return false;
+      }
+      for (auto const & kv : m_keyToAge)
+      {
+        if (kv.second > m_age)
+          return false;
+        if (m_ageToKey.find(kv.second) == m_ageToKey.cend())
+          return false;
+      }
+      return true;
+    }
+
+    /// \returns true if |key| and its age are contained in |m_keyToAge| and |m_keyToAge|.
+    /// \note It's a time consumption method and should be called for tests only.
+    bool IsKeyValidForTesting(Key const & key) const
+    {
+      auto const keyToAgeId = m_keyToAge.find(key);
+      if (keyToAgeId == m_keyToAge.cend())
+        return false;
+      auto const ageToKeyIt = m_ageToKey.find(keyToAgeId->second);
+      if (ageToKeyIt == m_ageToKey.cend())
+        return false;
+      return key == ageToKeyIt->second;
+    }
+
+  private:
+    size_t m_age = 0;
+    std::map<size_t, Key> m_ageToKey;
+    std::map<Key, size_t> m_keyToAge;
+  };
+
+  size_t const m_maxCacheSize;
+  Loader const m_loader;
+  std::unordered_map<Key, Value> m_cache;
+  KeyAge m_keyAge;
+};

--- a/base/lru_cache.hpp
+++ b/base/lru_cache.hpp
@@ -14,25 +14,22 @@ class LruCache
   template <typename K, typename V> friend class LruCacheTest;
   template <typename K, typename V> friend class LruCacheKeyAgeTest;
 public:
-  using Loader = std::function<void(Key const & key, Value & value)>;
-
   /// \param maxCacheSize Maximum size of the cache in number of items. It should be one or greater.
   /// \param loader Function which is called if it's necessary to load a new item for the cache.
   /// For the same |key| should be loaded the same |value|.
-  LruCache(size_t maxCacheSize, Loader const & loader)
-    : m_maxCacheSize(maxCacheSize), m_loader(loader)
+  LruCache(size_t maxCacheSize) : m_maxCacheSize(maxCacheSize)
   {
     CHECK_GREATER(maxCacheSize, 0, ());
   }
 
-  /// \brief Loads value, if it's necessary, by |key| with |m_loader|, puts it to |m_cache| and
-  /// returns the reference to the value to |m_cache|.
-  Value const & GetValue(Key const & key)
+  // Find value by @key. If @key is found, returns reference to its value.
+  Value & Find(Key const & key, bool & found)
   {
     auto const it = m_cache.find(key);
     if (it != m_cache.cend())
     {
       m_keyAge.UpdateAge(key);
+      found = true;
       return it->second;
     }
 
@@ -44,7 +41,7 @@ public:
 
     m_keyAge.InsertKey(key);
     Value & value = m_cache[key];
-    m_loader(key, value);
+    found = false;
     return value;
   }
 
@@ -158,7 +155,6 @@ private:
   };
 
   size_t const m_maxCacheSize;
-  Loader const m_loader;
   std::unordered_map<Key, Value> m_cache;
   KeyAge m_keyAge;
 };

--- a/base/lru_cache.hpp
+++ b/base/lru_cache.hpp
@@ -17,7 +17,7 @@ public:
   /// \param maxCacheSize Maximum size of the cache in number of items. It should be one or greater.
   /// \param loader Function which is called if it's necessary to load a new item for the cache.
   /// For the same |key| should be loaded the same |value|.
-  LruCache(size_t maxCacheSize) : m_maxCacheSize(maxCacheSize)
+  explicit LruCache(size_t maxCacheSize) : m_maxCacheSize(maxCacheSize)
   {
     CHECK_GREATER(maxCacheSize, 0, ());
   }
@@ -47,7 +47,7 @@ public:
 
   /// \brief Checks for coherence class params.
   /// \note It's a time consumption method and should be called for tests only.
-  bool IsValid() const
+  bool IsValidForTesting() const
   {
     if (!m_keyAge.IsValidForTesting())
       return false;
@@ -65,7 +65,7 @@ private:
   /// \brief This class support cross mapping from age to key and for key to age.
   /// It lets effectively get least recently used key (key with minimum value of age)
   /// and find key age by its value to update the key age.
-  /// \note Size of |m_ageToKey| and |m_ageToKey| should be the sameß.
+  /// \note Size of |m_ageToKey| and |m_ageToKey| should be the same.
   /// All keys of |m_ageToKey| should be values of |m_ageToKey| and on the contrary
   /// all keys of |m_ageToKey| should be values of |m_ageToKey|.
   /// \note Ages should be unique for all keys.

--- a/coding/coding_tests/text_storage_tests.cpp
+++ b/coding/coding_tests/text_storage_tests.cpp
@@ -125,7 +125,7 @@ UNIT_TEST(TextStorage_Random)
   TEST_EQUAL(ts.GetNumStrings(), strings.size(), ());
   for (size_t i = 0; i < ts.GetNumStrings(); ++i)
     TEST_EQUAL(ts.ExtractString(i), strings[i], ());
-  ts.ClearCache();
+
   for (size_t i = ts.GetNumStrings() - 1; i < ts.GetNumStrings(); --i)
     TEST_EQUAL(ts.ExtractString(i), strings[i], ());
 }

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		3D78157B1F3D89EC0068B6AC /* waiter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D78157A1F3D89EC0068B6AC /* waiter.hpp */; };
 		3DBD7B95240FB11200ED9FE8 /* checked_cast_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DBD7B94240FB11200ED9FE8 /* checked_cast_tests.cpp */; };
 		564BB445206E89ED00BDD211 /* fifo_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 564BB444206E89ED00BDD211 /* fifo_cache.hpp */; };
+		56290B8A206D0887003892E0 /* lru_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56290B89206D0887003892E0 /* lru_cache.hpp */; };
 		56B1A0741E69DE4D00395022 /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56B1A0711E69DE4D00395022 /* random.cpp */; };
 		56B1A0751E69DE4D00395022 /* random.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0721E69DE4D00395022 /* random.hpp */; };
 		56B1A0761E69DE4D00395022 /* small_set.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0731E69DE4D00395022 /* small_set.hpp */; };
@@ -234,6 +235,7 @@
 		3DBD7B94240FB11200ED9FE8 /* checked_cast_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = checked_cast_tests.cpp; sourceTree = "<group>"; };
 		564BB444206E89ED00BDD211 /* fifo_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fifo_cache.hpp; sourceTree = "<group>"; };
 		564BB446206E8A4D00BDD211 /* fifo_cache_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fifo_cache_test.cpp; sourceTree = "<group>"; };
+		56290B89206D0887003892E0 /* lru_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lru_cache.hpp; sourceTree = "<group>"; };
 		56B1A0711E69DE4D00395022 /* random.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = random.cpp; sourceTree = "<group>"; };
 		56B1A0721E69DE4D00395022 /* random.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = random.hpp; sourceTree = "<group>"; };
 		56B1A0731E69DE4D00395022 /* small_set.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = small_set.hpp; sourceTree = "<group>"; };
@@ -433,6 +435,7 @@
 				3917FA56211E009700937DF4 /* get_time.hpp */,
 				3917FA52211E008C00937DF4 /* clustering_map.hpp */,
 				564BB444206E89ED00BDD211 /* fifo_cache.hpp */,
+				56290B89206D0887003892E0 /* lru_cache.hpp */,
 				675341851A3F57E400A0A8C3 /* array_adapters.hpp */,
 				675341861A3F57E400A0A8C3 /* assert.hpp */,
 				675341871A3F57E400A0A8C3 /* base.cpp */,
@@ -551,6 +554,7 @@
 				675341E31A3F57E400A0A8C3 /* math.hpp in Headers */,
 				3446C6731DDCA96300146687 /* levenshtein_dfa.hpp in Headers */,
 				56B1A0751E69DE4D00395022 /* random.hpp in Headers */,
+				56290B8A206D0887003892E0 /* lru_cache.hpp in Headers */,
 				675341E21A3F57E400A0A8C3 /* macros.hpp in Headers */,
 				672DD4C51E0425600078E13C /* observer_list.hpp in Headers */,
 				675341EF1A3F57E400A0A8C3 /* rolling_hash.hpp in Headers */,

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -83,7 +83,7 @@
 		3DBD7B95240FB11200ED9FE8 /* checked_cast_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DBD7B94240FB11200ED9FE8 /* checked_cast_tests.cpp */; };
 		564BB445206E89ED00BDD211 /* fifo_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 564BB444206E89ED00BDD211 /* fifo_cache.hpp */; };
 		56290B8A206D0887003892E0 /* lru_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56290B89206D0887003892E0 /* lru_cache.hpp */; };
-		56290B8C206D0938003892E0 /* lru_cache_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56290B8B206D0937003892E0 /* lru_cache_test.cpp */; };
+		56290B8C206D0938003892E0 /* lru_cache_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56290B8B206D0937003892E0 /* lru_cache_tests.cpp */; };
 		56B1A0741E69DE4D00395022 /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56B1A0711E69DE4D00395022 /* random.cpp */; };
 		56B1A0751E69DE4D00395022 /* random.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0721E69DE4D00395022 /* random.hpp */; };
 		56B1A0761E69DE4D00395022 /* small_set.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0731E69DE4D00395022 /* small_set.hpp */; };
@@ -237,7 +237,7 @@
 		564BB444206E89ED00BDD211 /* fifo_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fifo_cache.hpp; sourceTree = "<group>"; };
 		564BB446206E8A4D00BDD211 /* fifo_cache_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fifo_cache_test.cpp; sourceTree = "<group>"; };
 		56290B89206D0887003892E0 /* lru_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lru_cache.hpp; sourceTree = "<group>"; };
-		56290B8B206D0937003892E0 /* lru_cache_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lru_cache_test.cpp; sourceTree = "<group>"; };
+		56290B8B206D0937003892E0 /* lru_cache_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lru_cache_tests.cpp; sourceTree = "<group>"; };
 		56B1A0711E69DE4D00395022 /* random.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = random.cpp; sourceTree = "<group>"; };
 		56B1A0721E69DE4D00395022 /* random.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = random.hpp; sourceTree = "<group>"; };
 		56B1A0731E69DE4D00395022 /* small_set.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = small_set.hpp; sourceTree = "<group>"; };
@@ -356,7 +356,7 @@
 				39F995E220F55B8A0034F977 /* visitor_tests.cpp */,
 				39BC707420F55B6700A6EC20 /* clustering_map_tests.cpp */,
 				564BB446206E8A4D00BDD211 /* fifo_cache_test.cpp */,
-				56290B8B206D0937003892E0 /* lru_cache_test.cpp */,
+				56290B8B206D0937003892E0 /* lru_cache_tests.cpp */,
 				39B89C391FD1898A001104AF /* control_flow_tests.cpp */,
 				67E40EC71E4DC0D500A6D200 /* small_set_test.cpp */,
 				3446C67E1DDCAA6E00146687 /* newtype_test.cpp */,
@@ -795,7 +795,7 @@
 				67B52B601AD3C84E00664C17 /* thread_checker.cpp in Sources */,
 				675341E71A3F57E400A0A8C3 /* normalize_unicode.cpp in Sources */,
 				675341E11A3F57E400A0A8C3 /* lower_case.cpp in Sources */,
-				56290B8C206D0938003892E0 /* lru_cache_test.cpp in Sources */,
+				56290B8C206D0938003892E0 /* lru_cache_tests.cpp in Sources */,
 				672DD4C11E0425600078E13C /* condition.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		3DBD7B95240FB11200ED9FE8 /* checked_cast_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DBD7B94240FB11200ED9FE8 /* checked_cast_tests.cpp */; };
 		564BB445206E89ED00BDD211 /* fifo_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 564BB444206E89ED00BDD211 /* fifo_cache.hpp */; };
 		56290B8A206D0887003892E0 /* lru_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56290B89206D0887003892E0 /* lru_cache.hpp */; };
+		56290B8C206D0938003892E0 /* lru_cache_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56290B8B206D0937003892E0 /* lru_cache_test.cpp */; };
 		56B1A0741E69DE4D00395022 /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56B1A0711E69DE4D00395022 /* random.cpp */; };
 		56B1A0751E69DE4D00395022 /* random.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0721E69DE4D00395022 /* random.hpp */; };
 		56B1A0761E69DE4D00395022 /* small_set.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0731E69DE4D00395022 /* small_set.hpp */; };
@@ -236,6 +237,7 @@
 		564BB444206E89ED00BDD211 /* fifo_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fifo_cache.hpp; sourceTree = "<group>"; };
 		564BB446206E8A4D00BDD211 /* fifo_cache_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fifo_cache_test.cpp; sourceTree = "<group>"; };
 		56290B89206D0887003892E0 /* lru_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lru_cache.hpp; sourceTree = "<group>"; };
+		56290B8B206D0937003892E0 /* lru_cache_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lru_cache_test.cpp; sourceTree = "<group>"; };
 		56B1A0711E69DE4D00395022 /* random.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = random.cpp; sourceTree = "<group>"; };
 		56B1A0721E69DE4D00395022 /* random.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = random.hpp; sourceTree = "<group>"; };
 		56B1A0731E69DE4D00395022 /* small_set.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = small_set.hpp; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 				39F995E220F55B8A0034F977 /* visitor_tests.cpp */,
 				39BC707420F55B6700A6EC20 /* clustering_map_tests.cpp */,
 				564BB446206E8A4D00BDD211 /* fifo_cache_test.cpp */,
+				56290B8B206D0937003892E0 /* lru_cache_test.cpp */,
 				39B89C391FD1898A001104AF /* control_flow_tests.cpp */,
 				67E40EC71E4DC0D500A6D200 /* small_set_test.cpp */,
 				3446C67E1DDCAA6E00146687 /* newtype_test.cpp */,
@@ -792,6 +795,7 @@
 				67B52B601AD3C84E00664C17 /* thread_checker.cpp in Sources */,
 				675341E71A3F57E400A0A8C3 /* normalize_unicode.cpp in Sources */,
 				675341E11A3F57E400A0A8C3 /* lower_case.cpp in Sources */,
+				56290B8C206D0938003892E0 /* lru_cache_test.cpp in Sources */,
 				672DD4C11E0425600078E13C /* condition.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Сейчас у нас TextStorage используется для ugc, википедии и букмарок. Планируется также использовать его для метадаты: https://github.com/mapsme/omim/pull/13653.

В данный момент размер кеша ничем не ограничен и кеш никогда не сбрасывается (только при уничтожении BlockedTextStorageReader), что может быть не очень хорошо с точки зрения потребляемой памяти. Предлагается использовать кеш ограниченного размера.

Выбор реализации и размера кеша делала так:
- по аналитическим оценкам и результатам профилирования наиболее загруженным местом для чтения TextStorage является чтение метадаты (https://github.com/mapsme/omim/pull/13653) при поиске отелей на карте: в этот момент drape читает метадату т.к. использует данные из неё для вытеснения, дрейп читает метадату для высоты зданий (3д), поиск читает метадату для отельного фильтра и для каждого конечного результата.
- измерялось среднее время чтения метадаты для сценария "минуту активно шаримся по карте москвы с влюченым поиском"
- для fifo cache при размере кеша 32 блока (1 блок 1000 байт, всего в метадате 1487 блоков) просадка по производительности по сравнению с "бесконечным" кешом составляет 10-12%. При размере кеша 100 блоков просадки почти нет. Без кеша просадка в 3 раза.
- для lru cache при размере кеша 32 блока просадка 5-7%, для крайних значений всё то же самое (что логично)
- т.к. размер кешируемых объектов относительно большой (1000 байт блок текста + таблица оффсетов внутри блока), по сравнению с ними большее количество дополнительной информации хранящееся в lru cache кажется не существенным.

Для разных потребителей (ugc, wiki, букмарки) есть возможность по необходимости задать свой размер кеша.

Предлагается возродить кеш из https://github.com/mapsme/omim/pull/8404 с небольшими изменениями: в TextStorage неудобно задавать функцию загрузки значения для кеша на этапе конструирования класса, т.к. reader в этот момент может быть неизвестен (например у нас класс Deserializer хочет хранить в поле TextStorage, но чтобы передать ему loader для кеша нужно получить reader, а для этого нужно сначала десериализовать header и узнать на какую область следует смотреть reader-у, а это на этапе конструирования класса довольно тяжело). Т.к. у нас пока что TextStorage является единственным потребителем lru cache, я посчитала, что красивее будет переделать интерфейс для lru cache аналогично base/cache.hpp .