### PR TITLE
[indexer] Lazy metadata read.

### DIFF
--- a/drape_frontend/rule_drawer.cpp
+++ b/drape_frontend/rule_drawer.cpp
@@ -52,10 +52,9 @@ double GetBuildingHeightInMeters(FeatureType & f)
   double constexpr kDefaultHeightInMeters = 3.0;
   double constexpr kMetersPerLevel = 3.0;
 
-  feature::Metadata const & md = f.GetMetadata();
   double heightInMeters = kDefaultHeightInMeters;
 
-  std::string value = md.Get(feature::Metadata::FMD_HEIGHT);
+  std::string value = f.GetMetadata(feature::Metadata::FMD_HEIGHT);
   if (!value.empty())
   {
     if (!strings::to_double(value, heightInMeters))
@@ -63,7 +62,7 @@ double GetBuildingHeightInMeters(FeatureType & f)
   }
   else
   {
-    value = md.Get(feature::Metadata::FMD_BUILDING_LEVELS);
+    value = f.GetMetadata(feature::Metadata::FMD_BUILDING_LEVELS);
     if (!value.empty())
     {
       if (strings::to_double(value, heightInMeters))
@@ -75,8 +74,7 @@ double GetBuildingHeightInMeters(FeatureType & f)
 
 double GetBuildingMinHeightInMeters(FeatureType & f)
 {
-  feature::Metadata const & md = f.GetMetadata();
-  std::string value = md.Get(feature::Metadata::FMD_MIN_HEIGHT);
+  std::string value = f.GetMetadata(feature::Metadata::FMD_MIN_HEIGHT);
   if (value.empty())
     return 0.0;
 
@@ -92,12 +90,11 @@ df::BaseApplyFeature::HotelData ExtractHotelData(FeatureType & f)
   df::BaseApplyFeature::HotelData result;
   if (ftypes::IsBookingChecker::Instance()(f))
   {
-    auto const & metadata = f.GetMetadata();
     result.m_isHotel = true;
-    result.m_rating = metadata.Get(feature::Metadata::FMD_RATING);
-    if (!strings::to_int(metadata.Get(feature::Metadata::FMD_STARS), result.m_stars))
+    result.m_rating = f.GetMetadata(feature::Metadata::FMD_RATING);
+    if (!strings::to_int(f.GetMetadata(feature::Metadata::FMD_STARS), result.m_stars))
       result.m_stars = 0;
-    if (!strings::to_int(metadata.Get(feature::Metadata::FMD_PRICE_RATE), result.m_priceCategory))
+    if (!strings::to_int(f.GetMetadata(feature::Metadata::FMD_PRICE_RATE), result.m_priceCategory))
       result.m_priceCategory = 0;
   }
   return result;

--- a/feature_list/feature_list.cpp
+++ b/feature_list/feature_list.cpp
@@ -205,9 +205,10 @@ public:
   {
     f.ParseBeforeStatistic();
     string const & category = GetReadableType(f);
+    auto const & meta = f.GetMetadata();
     // "operator" is a reserved word, hence "operatr". This word is pretty
     // common in C++ projects.
-    string const & operatr = f.GetMetadata().Get(feature::Metadata::FMD_OPERATOR);
+    string const & operatr = meta.Get(feature::Metadata::FMD_OPERATOR);
     auto const & osmIt = ft2osm.find(f.GetID().m_index);
     if ((!f.HasName() && operatr.empty()) ||
         (f.GetGeomType() == feature::GeomType::Line && category != "highway-pedestrian") ||
@@ -238,7 +239,7 @@ public:
     {
       // For sponsored types, adding invented sponsored ids (booking = 00) to the id tail.
       if (ftypes::IsBookingChecker::Instance()(f))
-        osmId = f.GetMetadata().Get(feature::Metadata::FMD_SPONSORED_ID) + "00";
+        osmId = meta.Get(feature::Metadata::FMD_SPONSORED_ID) + "00";
     }
     string const & uid = BuildUniqueId(ll, name);
     string const & lat = strings::to_string_with_digits_after_comma(ll.m_lat, 6);
@@ -261,17 +262,17 @@ public:
         addrHouse = addr.GetHouseNumber();
       }
     }
-    string const & phone = f.GetMetadata().Get(feature::Metadata::FMD_PHONE_NUMBER);
-    string const & website = f.GetMetadata().Get(feature::Metadata::FMD_WEBSITE);
-    string cuisine = f.GetMetadata().Get(feature::Metadata::FMD_CUISINE);
+    string const & phone = meta.Get(feature::Metadata::FMD_PHONE_NUMBER);
+    string const & website = meta.Get(feature::Metadata::FMD_WEBSITE);
+    string cuisine = meta.Get(feature::Metadata::FMD_CUISINE);
     replace(cuisine.begin(), cuisine.end(), ';', ',');
-    string const & stars = f.GetMetadata().Get(feature::Metadata::FMD_STARS);
-    string const & internet = f.GetMetadata().Get(feature::Metadata::FMD_INTERNET);
-    string const & denomination = f.GetMetadata().Get(feature::Metadata::FMD_DENOMINATION);
+    string const & stars = meta.Get(feature::Metadata::FMD_STARS);
+    string const & internet = meta.Get(feature::Metadata::FMD_INTERNET);
+    string const & denomination = meta.Get(feature::Metadata::FMD_DENOMINATION);
     string const & wheelchair = GetWheelchairType(f);
-    string const & opening_hours = f.GetMetadata().Get(feature::Metadata::FMD_OPEN_HOURS);
-    string const & wikipedia = f.GetMetadata().GetWikiURL();
-    string const & floor = f.GetMetadata().Get(feature::Metadata::FMD_LEVEL);
+    string const & opening_hours = meta.Get(feature::Metadata::FMD_OPEN_HOURS);
+    string const & wikipedia = meta.GetWikiURL();
+    string const & floor = meta.Get(feature::Metadata::FMD_LEVEL);
     string const & fee = strings::EndsWith(category, "-fee") ? "yes" : "";
     string const & atm = HasAtm(f) ? "yes" : "";
 

--- a/generator/generator_tests_support/test_feature.cpp
+++ b/generator/generator_tests_support/test_feature.cpp
@@ -89,7 +89,7 @@ void TestFeature::Init()
 
 bool TestFeature::Matches(FeatureType & feature) const
 {
-  istringstream is(feature.GetMetadata().Get(Metadata::FMD_TEST_ID));
+  istringstream is(feature.GetMetadata(Metadata::FMD_TEST_ID));
   uint64_t id;
   is >> id;
   return id == m_id;

--- a/generator/search_index_builder.cpp
+++ b/generator/search_index_builder.cpp
@@ -247,7 +247,7 @@ bool InsertPostcodes(FeatureType & f, function<void(strings::UniString const &)>
   using namespace search;
 
   auto const & postBoxChecker = ftypes::IsPostBoxChecker::Instance();
-  string const postcode = f.GetMetadata().Get(feature::Metadata::FMD_POSTCODE);
+  string const postcode = f.GetMetadata(feature::Metadata::FMD_POSTCODE);
   vector<string> postcodes;
   if (!postcode.empty())
     postcodes.push_back(postcode);
@@ -332,17 +332,17 @@ public:
 
     if (ftypes::IsAirportChecker::Instance()(types))
     {
-      string const iata = f.GetMetadata().Get(feature::Metadata::FMD_AIRPORT_IATA);
+      string const iata = f.GetMetadata(feature::Metadata::FMD_AIRPORT_IATA);
       if (!iata.empty())
         inserter(StringUtf8Multilang::kDefaultCode, iata);
     }
 
     // Index operator to support "Sberbank ATM" for objects with amenity=atm and operator=Sberbank.
-    string const op = f.GetMetadata().Get(feature::Metadata::FMD_OPERATOR);
+    string const op = f.GetMetadata(feature::Metadata::FMD_OPERATOR);
     if (!op.empty())
       inserter(StringUtf8Multilang::kDefaultCode, op);
 
-    string const brand = f.GetMetadata().Get(feature::Metadata::FMD_BRAND);
+    string const brand = f.GetMetadata(feature::Metadata::FMD_BRAND);
     if (!brand.empty())
     {
       auto const & brands = indexer::GetDefaultBrands();

--- a/generator/utils.cpp
+++ b/generator/utils.cpp
@@ -117,8 +117,7 @@ bool ParseFeatureIdToTestIdMapping(std::string const & path,
 {
   bool success = true;
   feature::ForEachFeature(path, [&](FeatureType & feature, uint32_t fid) {
-    auto const & metatada = feature.GetMetadata();
-    auto const testIdStr = metatada.Get(feature::Metadata::FMD_TEST_ID);
+    auto const testIdStr = feature.GetMetadata(feature::Metadata::FMD_TEST_ID);
     uint64_t testId;
     if (!strings::to_uint64(testIdStr, testId))
     {

--- a/indexer/drules_selector.cpp
+++ b/indexer/drules_selector.cpp
@@ -160,7 +160,7 @@ bool GetRating(FeatureType & ft, double & rating)
 {
   double constexpr kDefaultRating = 0.0;
 
-  string ratingStr = ft.GetMetadata().Get(feature::Metadata::FMD_RATING);
+  string ratingStr = ft.GetMetadata(feature::Metadata::FMD_RATING);
   if (ratingStr.empty() || !strings::to_double(ratingStr, rating))
     rating = kDefaultRating;
   return true;

--- a/indexer/feature.hpp
+++ b/indexer/feature.hpp
@@ -157,7 +157,11 @@ public:
   uint64_t GetPopulation();
   std::string GetRoadNumber();
 
-  feature::Metadata & GetMetadata();
+  feature::Metadata const & GetMetadata();
+
+  // Gets single metadata string. Does not parse all metadata.
+  std::string GetMetadata(feature::Metadata::EType type);
+  bool HasMetadata(feature::Metadata::EType type);
 
   /// @name Statistic functions.
   //@{
@@ -195,8 +199,12 @@ private:
     bool m_points = false;
     bool m_triangles = false;
     bool m_metadata = false;
+    bool m_metaIds = false;
 
-    void Reset() { m_types = m_common = m_header2 = m_points = m_triangles = m_metadata = false; }
+    void Reset()
+    {
+      m_types = m_common = m_header2 = m_points = m_triangles = m_metadata = m_metaIds = false;
+    }
   };
 
   struct Offsets
@@ -218,6 +226,7 @@ private:
   void ParseCommon();
   void ParseHeader2();
   void ParseMetadata();
+  void ParseMetaIds();
   void ParseGeometryAndTriangles(int scale);
 
   uint8_t m_header = 0;
@@ -235,6 +244,7 @@ private:
   using Points = buffer_vector<m2::PointD, kStaticBufferSize>;
   Points m_points, m_triangles;
   feature::Metadata m_metadata;
+  indexer::MetadataDeserializer::MetaIds m_metaIds;
 
   // Non-owning pointer to shared load info. SharedLoadInfo created once per FeaturesVector.
   feature::SharedLoadInfo const * m_loadInfo = nullptr;

--- a/indexer/indexer_tests/CMakeLists.txt
+++ b/indexer/indexer_tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(
   features_vector_test.cpp
   index_builder_test.cpp
   interval_index_test.cpp
+  metadata_serdes_tests.cpp
   mwm_set_test.cpp
   postcodes_matcher_tests.cpp
   rank_table_test.cpp

--- a/indexer/indexer_tests/features_vector_test.cpp
+++ b/indexer/indexer_tests/features_vector_test.cpp
@@ -65,7 +65,7 @@ UNIT_TEST(FeaturesVectorTest_ParseMetadata)
   map<string, int> actual;
   fv.ForEach([&](FeatureType & ft, uint32_t index)
              {
-               string postcode = ft.GetMetadata().Get(feature::Metadata::FMD_POSTCODE);
+               string postcode = ft.GetMetadata(feature::Metadata::FMD_POSTCODE);
                if (!postcode.empty())
                  ++actual[postcode];
              });

--- a/indexer/indexer_tests/metadata_serdes_tests.cpp
+++ b/indexer/indexer_tests/metadata_serdes_tests.cpp
@@ -1,0 +1,81 @@
+#include "testing/testing.hpp"
+
+#include "indexer/feature_meta.hpp"
+#include "indexer/metadata_serdes.hpp"
+
+#include "coding/reader.hpp"
+#include "coding/writer.hpp"
+
+#include "base/string_utils.hpp"
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace feature;
+using namespace indexer;
+using namespace std;
+
+namespace
+{
+using Buffer = vector<uint8_t>;
+
+UNIT_TEST(MetadataSerDesTest_Smoke)
+{
+  Buffer buffer;
+
+  auto const genMeta = [](uint32_t i) {
+    feature::Metadata meta;
+    meta.Set(Metadata::FMD_TEST_ID, strings::to_string(i));
+    return meta;
+  };
+
+  uint32_t constexpr kMetaNumber = 1000;
+  map<uint32_t, Metadata> values;
+  for (uint32_t i = 0; i < kMetaNumber; ++i)
+    values.emplace(i, genMeta(i));
+
+  {
+    MetadataBuilder builder;
+
+    for (auto const & kv : values)
+      builder.Put(kv.first, kv.second);
+
+    MemWriter<Buffer> writer(buffer);
+    builder.Freeze(writer);
+  }
+
+  {
+    MemReader reader(buffer.data(), buffer.size());
+    auto deserializer = MetadataDeserializer::Load(reader);
+    TEST(deserializer.get(), ());
+
+    for (uint32_t i = 0; i < kMetaNumber; ++i)
+    {
+      Metadata meta;
+      TEST(deserializer->Get(i, meta), ());
+      TEST(meta.Equals(values[i]), (meta, i));
+    }
+  }
+
+  {
+    MemReader reader(buffer.data(), buffer.size());
+    auto deserializer = MetadataDeserializer::Load(reader);
+    TEST(deserializer.get(), ());
+
+    for (uint32_t i = 0; i < kMetaNumber; ++i)
+    {
+      MetadataDeserializer::MetaIds ids;
+      TEST(deserializer->GetIds(i, ids), ());
+      auto const & meta = values[i];
+      TEST_EQUAL(meta.Size(), 1, (meta));
+      TEST_EQUAL(ids.size(), 1, (ids));
+      TEST(meta.Has(Metadata::FMD_TEST_ID), (meta));
+      TEST_EQUAL(ids[0].first, Metadata::FMD_TEST_ID, (ids));
+      TEST_EQUAL(meta.Get(Metadata::FMD_TEST_ID), deserializer->GetMetaById(ids[0].second),
+                 (i, meta, ids));
+    }
+  }
+}
+}  // namespace

--- a/indexer/metadata_serdes.cpp
+++ b/indexer/metadata_serdes.cpp
@@ -45,7 +45,7 @@ bool MetadataDeserializer::GetIds(uint32_t featureId, MetaIds & metaIds) const
   return m_map->GetThreadsafe(featureId, metaIds);
 }
 
-std::string MetadataDeserializer::GetMetaById(uint8_t id)
+std::string MetadataDeserializer::GetMetaById(uint32_t id)
 {
   lock_guard<mutex> guard(m_stringsMutex);
   return m_strings.ExtractString(*m_stringsSubreader, id);

--- a/indexer/metadata_serdes.cpp
+++ b/indexer/metadata_serdes.cpp
@@ -25,10 +25,10 @@ void MetadataDeserializer::Header::Read(Reader & reader)
   m_metadataMapSize = ReadPrimitiveFromSource<uint32_t>(source);
 }
 
-bool MetadataDeserializer::Get(uint32_t id, feature::MetadataBase & meta)
+bool MetadataDeserializer::Get(uint32_t featureId, feature::MetadataBase & meta)
 {
   MetaIds metaIds;
-  if (!m_map->GetThreadsafe(id, metaIds))
+  if (!m_map->GetThreadsafe(featureId, metaIds))
     return false;
 
   lock_guard<mutex> guard(m_stringsMutex);
@@ -38,6 +38,17 @@ bool MetadataDeserializer::Get(uint32_t id, feature::MetadataBase & meta)
     meta.Set(id.first, m_strings.ExtractString(*m_stringsSubreader, id.second));
   }
   return true;
+}
+
+bool MetadataDeserializer::GetIds(uint32_t featureId, MetaIds & metaIds) const
+{
+  return m_map->GetThreadsafe(featureId, metaIds);
+}
+
+std::string MetadataDeserializer::GetMetaById(uint8_t id)
+{
+  lock_guard<mutex> guard(m_stringsMutex);
+  return m_strings.ExtractString(*m_stringsSubreader, id);
 }
 
 // static

--- a/indexer/metadata_serdes.hpp
+++ b/indexer/metadata_serdes.hpp
@@ -72,7 +72,7 @@ public:
   WARN_UNUSED_RESULT bool GetIds(uint32_t featureId, MetaIds & metaIds) const;
 
   // Gets single metadata string from text storage. This method is threadsafe.
-  std::string GetMetaById(uint8_t id);
+  std::string GetMetaById(uint32_t id);
 
 private:
   using Map = MapUint32ToValue<MetaIds>;

--- a/indexer/metadata_serdes.hpp
+++ b/indexer/metadata_serdes.hpp
@@ -66,6 +66,14 @@ public:
   // This method is threadsafe.
   WARN_UNUSED_RESULT bool Get(uint32_t featureId, feature::MetadataBase & meta);
 
+  // Tries to get string ids for metagata of the feature with id |featureId|. Returns false
+  // if table does not have entry for the feature.
+  // This method is threadsafe.
+  WARN_UNUSED_RESULT bool GetIds(uint32_t featureId, MetaIds & metaIds) const;
+
+  // Gets single metadata string from text storage. This method is threadsafe.
+  std::string GetMetaById(uint8_t id);
+
 private:
   using Map = MapUint32ToValue<MetaIds>;
 

--- a/map/booking_availability_filter.cpp
+++ b/map/booking_availability_filter.cpp
@@ -211,7 +211,7 @@ void PrepareData(DataSource const & dataSource, search::Results const & results,
     if (!ftypes::IsBookingChecker::Instance()(*ft))
       continue;
 
-    auto hotelId = ft->GetMetadata().Get(feature::Metadata::FMD_SPONSORED_ID);
+    auto hotelId = ft->GetMetadata(feature::Metadata::FMD_SPONSORED_ID);
     auto info = cache.Get(hotelId);
     auto const status = info.m_status;
 
@@ -252,7 +252,7 @@ void PrepareData(DataSource const & dataSource, std::vector<FeatureID> const & f
     if (!ftypes::IsBookingChecker::Instance()(*ft))
       continue;
 
-    auto const hotelId = ft->GetMetadata().Get(feature::Metadata::FMD_SPONSORED_ID);
+    auto const hotelId = ft->GetMetadata(feature::Metadata::FMD_SPONSORED_ID);
     auto info = cache.Get(hotelId);
     auto const status = info.m_status;
 
@@ -377,7 +377,7 @@ void AvailabilityFilter::GetFeaturesFromCache(search::Results const & results,
       continue;
     }
 
-    auto const & hotelId = ft->GetMetadata().Get(feature::Metadata::FMD_SPONSORED_ID);
+    auto const & hotelId = ft->GetMetadata(feature::Metadata::FMD_SPONSORED_ID);
 
     auto info = m_cache->Get(hotelId);
     if (info.m_status == availability::Cache::HotelStatus::Available)

--- a/map/map_tests/booking_filter_test.cpp
+++ b/map/map_tests/booking_filter_test.cpp
@@ -191,7 +191,7 @@ UNIT_CLASS_TEST(TestMwmEnvironment, BookingFilter_ProcessorSmoke)
       search::Result result(ft.GetID(), ft.GetCenter(), name, "", 0, details);
       InsertResult(result, results);
 
-      auto const sponsoredId = ft.GetMetadata().Get(feature::Metadata::FMD_SPONSORED_ID);
+      auto const sponsoredId = ft.GetMetadata(feature::Metadata::FMD_SPONSORED_ID);
 
       if (kAvailableHotels.find(sponsoredId) != kAvailableHotels.cend())
         InsertResult(result, expectedAvailabilityResults);
@@ -323,7 +323,7 @@ UNIT_CLASS_TEST(TestMwmEnvironment, BookingFilter_ApplyFilterOntoWithFeatureIds)
 
       allFeatureIds.push_back(ft.GetID());
 
-      auto hotelId = ft.GetMetadata().Get(feature::Metadata::FMD_SPONSORED_ID);
+      auto hotelId = ft.GetMetadata(feature::Metadata::FMD_SPONSORED_ID);
       if (kHotelIds.cend() != std::find(kHotelIds.cbegin(), kHotelIds.cend(), hotelId))
         expectedFeatureIds.push_back(ft.GetID());
     },

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -210,7 +210,7 @@ void RoadGeometry::Load(VehicleModelInterface const & vehicleModel, FeatureType 
 
   if (m_routingOptions.Has(RoutingOptions::Road::Ferry))
   {
-    auto const durationHours = feature.GetMetadata().Get(feature::Metadata::FMD_DURATION);
+    auto const durationHours = feature.GetMetadata(feature::Metadata::FMD_DURATION);
     auto const roadLenKm = GetRoadLengthM() / 1000.0;
     double const durationH = CalcFerryDurationHours(durationHours, roadLenKm);
 

--- a/search/hotels_filter.cpp
+++ b/search/hotels_filter.cpp
@@ -27,19 +27,17 @@ void Description::FromFeature(FeatureType & ft)
   m_rating = Rating::kDefault;
   m_priceRate = PriceRate::kDefault;
 
-  auto const & metadata = ft.GetMetadata();
-
-  if (metadata.Has(feature::Metadata::FMD_RATING))
+  string const rating = ft.GetMetadata(feature::Metadata::FMD_RATING);
+  if (!rating.empty())
   {
-    string const rating = metadata.Get(feature::Metadata::FMD_RATING);
     float r;
     if (strings::to_float(rating, r))
       m_rating = r;
   }
 
-  if (metadata.Has(feature::Metadata::FMD_PRICE_RATE))
+  string const priceRate = ft.GetMetadata(feature::Metadata::FMD_PRICE_RATE);
+  if (!priceRate.empty())
   {
-    string const priceRate = metadata.Get(feature::Metadata::FMD_PRICE_RATE);
     int pr;
     if (strings::to_int(priceRate, pr))
       m_priceRate = pr;

--- a/search/intermediate_result.cpp
+++ b/search/intermediate_result.cpp
@@ -231,12 +231,10 @@ void FillDetails(FeatureType & ft, Result::Details & details)
   if (details.m_isInitialized)
     return;
 
-  feature::Metadata const & src = ft.GetMetadata();
+  details.m_airportIata = ft.GetMetadata(feature::Metadata::FMD_AIRPORT_IATA);
+  details.m_brand = ft.GetMetadata(feature::Metadata::FMD_BRAND);
 
-  details.m_airportIata = src.Get(feature::Metadata::FMD_AIRPORT_IATA);
-  details.m_brand = src.Get(feature::Metadata::FMD_BRAND);
-
-  string const openHours = src.Get(feature::Metadata::FMD_OPEN_HOURS);
+  string const openHours = ft.GetMetadata(feature::Metadata::FMD_OPEN_HOURS);
   if (!openHours.empty())
   {
     osmoh::OpeningHours const oh(openHours);
@@ -247,7 +245,7 @@ void FillDetails(FeatureType & ft, Result::Details & details)
     // In else case value us osm::Unknown, it's set in preview's constructor.
   }
 
-  if (strings::to_int(src.Get(feature::Metadata::FMD_STARS), details.m_stars))
+  if (strings::to_int(ft.GetMetadata(feature::Metadata::FMD_STARS), details.m_stars))
     details.m_stars = base::Clamp(details.m_stars, 0, 5);
   else
     details.m_stars = 0;
@@ -258,7 +256,7 @@ void FillDetails(FeatureType & ft, Result::Details & details)
 
   if (isSponsoredHotel)
   {
-    auto const r = src.Get(feature::Metadata::FMD_RATING);
+    auto const r = ft.GetMetadata(feature::Metadata::FMD_RATING);
     if (!r.empty())
     {
       float raw;
@@ -267,7 +265,7 @@ void FillDetails(FeatureType & ft, Result::Details & details)
     }
 
     int pricing;
-    if (!strings::to_int(src.Get(feature::Metadata::FMD_PRICE_RATE), pricing))
+    if (!strings::to_int(ft.GetMetadata(feature::Metadata::FMD_PRICE_RATE), pricing))
       pricing = 0;
     string pricingStr;
     CHECK_GREATER_OR_EQUAL(pricing, 0, ("Pricing must be positive!"));

--- a/search/ranker.cpp
+++ b/search/ranker.cpp
@@ -152,16 +152,16 @@ pair<NameScores, size_t> GetNameScores(FeatureType & ft, Geocoder::Params const 
 
   if (ftypes::IsAirportChecker::Instance()(ft))
   {
-    string const iata = ft.GetMetadata().Get(feature::Metadata::FMD_AIRPORT_IATA);
+    string const iata = ft.GetMetadata(feature::Metadata::FMD_AIRPORT_IATA);
     if (!iata.empty())
       UpdateNameScores(iata, StringUtf8Multilang::kDefaultCode, sliceNoCategories, bestScores);
   }
 
-  string const op = ft.GetMetadata().Get(feature::Metadata::FMD_OPERATOR);
+  string const op = ft.GetMetadata(feature::Metadata::FMD_OPERATOR);
   if (!op.empty())
     UpdateNameScores(op, StringUtf8Multilang::kDefaultCode, sliceNoCategories, bestScores);
 
-  string const brand = ft.GetMetadata().Get(feature::Metadata::FMD_BRAND);
+  string const brand = ft.GetMetadata(feature::Metadata::FMD_BRAND);
   if (!brand.empty())
   {
     auto const & brands = indexer::GetDefaultBrands();
@@ -438,9 +438,8 @@ private:
       info.m_hasName = ft.HasName();
       if (!info.m_hasName)
       {
-        auto const & meta = ft.GetMetadata();
-        info.m_hasName =
-            meta.Has(feature::Metadata::FMD_OPERATOR) || meta.Has(feature::Metadata::FMD_BRAND);
+        info.m_hasName = ft.HasMetadata(feature::Metadata::FMD_OPERATOR) ||
+                         ft.HasMetadata(feature::Metadata::FMD_BRAND);
       }
     }
     else

--- a/search/search_quality/booking_dataset_generator/booking_dataset_generator.cpp
+++ b/search/search_quality/booking_dataset_generator/booking_dataset_generator.cpp
@@ -179,7 +179,7 @@ int main(int argc, char * argv[])
   }
 
   auto const getAddress = [&](FeatureType & hotel) -> string {
-    auto const id = hotel.GetMetadata().Get(feature::Metadata::FMD_SPONSORED_ID);
+    auto const id = hotel.GetMetadata(feature::Metadata::FMD_SPONSORED_ID);
     if (id.empty())
       return {};
 

--- a/xcode/indexer/indexer.xcodeproj/project.pbxproj
+++ b/xcode/indexer/indexer.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		3D928F671D50F9FE001670E0 /* data_source_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3D928F651D50F9FE001670E0 /* data_source_helpers.cpp */; };
 		3D928F681D50F9FE001670E0 /* data_source_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D928F661D50F9FE001670E0 /* data_source_helpers.hpp */; };
 		40009062201F5CB000963E18 /* cell_value_pair.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4000905D201F5CAF00963E18 /* cell_value_pair.hpp */; };
+		4003775A252759020014A5B8 /* metadata_serdes_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 40037759252759020014A5B8 /* metadata_serdes_tests.cpp */; };
 		4043C0B924ACBA3300545FD8 /* transliteration_loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4043C0B724ACBA3200545FD8 /* transliteration_loader.cpp */; };
 		4043C0BA24ACBA3300545FD8 /* transliteration_loader.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4043C0B824ACBA3300545FD8 /* transliteration_loader.hpp */; };
 		40662D32236059BF006A124D /* tree_node.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 40662D2F236059BF006A124D /* tree_node.hpp */; };
@@ -297,6 +298,7 @@
 		3D928F651D50F9FE001670E0 /* data_source_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = data_source_helpers.cpp; sourceTree = "<group>"; };
 		3D928F661D50F9FE001670E0 /* data_source_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = data_source_helpers.hpp; sourceTree = "<group>"; };
 		4000905D201F5CAF00963E18 /* cell_value_pair.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cell_value_pair.hpp; sourceTree = "<group>"; };
+		40037759252759020014A5B8 /* metadata_serdes_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = metadata_serdes_tests.cpp; sourceTree = "<group>"; };
 		4043C0B724ACBA3200545FD8 /* transliteration_loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = transliteration_loader.cpp; sourceTree = "<group>"; };
 		4043C0B824ACBA3300545FD8 /* transliteration_loader.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = transliteration_loader.hpp; sourceTree = "<group>"; };
 		4052928E21496D2B00D821F1 /* categories_cuisines.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = categories_cuisines.txt; path = ../../data/categories_cuisines.txt; sourceTree = "<group>"; };
@@ -583,6 +585,7 @@
 		670C60F81AB0657700C38A8C /* indexer_tests */ = {
 			isa = PBXGroup;
 			children = (
+				40037759252759020014A5B8 /* metadata_serdes_tests.cpp */,
 				4067554B242BB04800EB8F8B /* read_features_tests.cpp */,
 				391C0C8522BD255E003DC252 /* feature_to_osm_tests.cpp */,
 				406970A121AEF2F10024DDB2 /* brands_tests.cpp */,
@@ -1033,6 +1036,7 @@
 			files = (
 				56C74C241C749E4700B71B9F /* search_string_utils.cpp in Sources */,
 				3D928F671D50F9FE001670E0 /* data_source_helpers.cpp in Sources */,
+				4003775A252759020014A5B8 /* metadata_serdes_tests.cpp in Sources */,
 				67F183731BD4FCF500AB1840 /* map_style.cpp in Sources */,
 				6758AED31BB4413000C26E27 /* drules_selector.cpp in Sources */,
 				6753411A1A3F540F00A0A8C3 /* feature_impl.cpp in Sources */,


### PR DESCRIPTION
Чтобы компенсировать потери производительности после перехода на сжатое хранилище строк в метадате, предлагаю читать строки лениво -- то есть не всю метадату, а только нужные строки. По измерениям в поиске/рендеринге так примерно в 3-5 раз быстрее чем читать всё.