### PR TITLE
[iOS] [Booking] Track selection and visit status for features, which does not have corresponding search mark atm

### DIFF
--- a/iphone/Maps/UI/Search/MWMSearchManager.mm
+++ b/iphone/Maps/UI/Search/MWMSearchManager.mm
@@ -333,10 +333,10 @@ using Observers = NSHashTable<Observer>;
   auto const navigationManagerState = [MWMNavigationDashboardManager sharedManager].state;
   [self viewHidden:navigationManagerState != MWMNavigationDashboardStateHidden];
   self.controlsManager.menuState = MWMBottomMenuStateHidden;
+  GetFramework().DeactivateMapSelection(true);
   [MWMSearch setSearchOnMap:YES];
   [self.tableViewController reloadData];
 
-  GetFramework().DeactivateMapSelection(true);
   [self.searchTextField resignFirstResponder];
 
   if (navigationManagerState == MWMNavigationDashboardStateNavigation) {

--- a/map/framework.cpp
+++ b/map/framework.cpp
@@ -2463,6 +2463,8 @@ void Framework::ActivateMapSelection()
   auto const & featureId = m_currentPlacePageInfo->GetID();
   bool const isHotel = m_currentPlacePageInfo->GetHotelType().has_value();
 
+  m_searchMarks.SetSelected(featureId);
+
   bool isSelectionShapeVisible = true;
   if (m_currentPlacePageInfo->GetSponsoredType() == place_page::SponsoredType::Booking &&
       m_searchMarks.IsThereSearchMarkForFeature(featureId))
@@ -2492,7 +2494,7 @@ void Framework::ActivateMapSelection()
 
 void Framework::DeactivateMapSelection(bool notifyUI)
 {
-  bool const somethingWasAlreadySelected = (m_currentPlacePageInfo.has_value());
+  bool const somethingWasAlreadySelected = m_currentPlacePageInfo.has_value();
 
   if (notifyUI && m_onPlacePageClose)
     m_onPlacePageClose(!somethingWasAlreadySelected);
@@ -2520,15 +2522,18 @@ void Framework::DeactivateHotelSearchMark()
 {
   if (!m_currentPlacePageInfo)
     return;
+
+  m_searchMarks.SetSelected({});
   if (m_currentPlacePageInfo->GetHotelType().has_value())
   {
-    if (GetSearchAPI().IsViewportSearchActive())
+    auto const & featureId = m_currentPlacePageInfo->GetID();
+    if (m_searchMarks.IsThereSearchMarkForFeature(featureId))
     {
-      auto const & featureId = m_currentPlacePageInfo->GetID();
-      if (m_searchMarks.IsThereSearchMarkForFeature(featureId))
-        m_searchMarks.OnDeactivate(featureId);
+      m_searchMarks.SetVisited(featureId);
+      m_searchMarks.OnDeactivate(featureId);
     }
-    else
+
+    if (!GetSearchAPI().IsViewportSearchActive())
     {
       GetBookmarkManager().GetEditSession().ClearGroup(UserMark::Type::SEARCH);
     }

--- a/map/search_mark.cpp
+++ b/map/search_mark.cpp
@@ -891,9 +891,19 @@ bool SearchMarks::IsUnavailable(FeatureID const & id) const
   return m_unavailable.find(id) != m_unavailable.cend();
 }
 
+void SearchMarks::SetVisited(FeatureID const & id)
+{
+  m_visitedSearchMarks.insert(id);
+}
+
 bool SearchMarks::IsVisited(FeatureID const & id) const
 {
   return m_visitedSearchMarks.find(id) != m_visitedSearchMarks.cend();
+}
+
+void SearchMarks::SetSelected(FeatureID const & id)
+{
+  m_selectedFeature = id;
 }
 
 bool SearchMarks::IsSelected(FeatureID const & id) const
@@ -907,7 +917,6 @@ void SearchMarks::ClearTrackedProperties()
     std::scoped_lock<std::mutex> lock(m_lock);
     m_unavailable.clear();
   }
-  m_visitedSearchMarks.clear();
   m_selectedFeature = {};
 }
 

--- a/map/search_mark.hpp
+++ b/map/search_mark.hpp
@@ -135,8 +135,10 @@ public:
   void SetUnavailable(std::vector<FeatureID> const & features, std::string const & reasonKey);
   bool IsUnavailable(FeatureID const & id) const;
 
+  void SetVisited(FeatureID const & id);
   bool IsVisited(FeatureID const & id) const;
 
+  void SetSelected(FeatureID const & id);
   bool IsSelected(FeatureID const & id) const;
 
   void ClearTrackedProperties();


### PR DESCRIPTION
На оси поведение ПП и поиска отличается от андроида. Кейс сброса выделения через закрытие PP не был учтён.
Также исправлен баг отсутствия выделения сёчмарки при клике по тексту POI и POI.

Отслеживание просмотренных отелей выполняется до перезапуска.

https://jira.mail.ru/browse/MAPSME-14544