### PR TITLE
[iOS] Fixed image width in bookmarks description in PP

### DIFF
--- a/iphone/Maps/Categories/NSAttributedString+HTML.swift
+++ b/iphone/Maps/Categories/NSAttributedString+HTML.swift
@@ -73,10 +73,14 @@ extension NSMutableAttributedString {
     enumerateAttribute(.attachment, in: NSMakeRange(0, length), options: []) { (value, range, _) in
       if let attachement = value as? NSTextAttachment,
         let image = attachement.image(forBounds: attachement.bounds, textContainer: NSTextContainer(), characterIndex: range.location) {
-        if image.size.width > estimatedWidth {
-          let newImage = resizeImage(image: image, scale: estimatedWidth/image.size.width) ?? image
+        if image.size.width > estimatedWidth || attachement.bounds.width > estimatedWidth {
           let resizedAttachment = NSTextAttachment()
-          resizedAttachment.image = newImage
+          if image.size.width > estimatedWidth {
+            let newImage = resizeImage(image: image, scale: estimatedWidth/image.size.width) ?? image
+            resizedAttachment.image = newImage
+          } else {
+            resizedAttachment.image = image
+          }
           addAttribute(.attachment, value: resizedAttachment, range: range)
         }
       }


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-14873

Добавлено дополнительное условие на attachement.bounds.  Бывают случаи image.size.width  > estimatedWidth но при этом attachement.bounds имеет меньшую или равную ширину, а бывает наоборот attachement.bounds > estimatedWidth (когда в теге img выставлен width=100% , в этом случае используем фикс из второго условия, при этом есть шанс что картинка будет меньше по ширине). 