### PR TITLE
[map] remove last usage of boost::optional

### DIFF
--- a/map/isolines_manager.cpp
+++ b/map/isolines_manager.cpp
@@ -95,7 +95,7 @@ void IsolinesManager::UpdateViewport(ScreenBase const & screen)
   if (screen.GlobalRect().GetLocalRect().IsEmptyInterior())
     return;
 
-  m_currentModelView.reset(screen);
+  m_currentModelView = screen;
   if (!IsEnabled())
     return;
 
@@ -171,7 +171,7 @@ void IsolinesManager::Invalidate()
     return;
   m_lastMwms.clear();
   if (m_currentModelView)
-    UpdateViewport(m_currentModelView.get());
+    UpdateViewport(*m_currentModelView);
 }
 
 isolines::Quality IsolinesManager::GetDataQuality(MwmSet::MwmId const & id) const

--- a/map/isolines_manager.hpp
+++ b/map/isolines_manager.hpp
@@ -16,10 +16,9 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
-
-#include <boost/optional.hpp>
 
 class IsolinesManager final
 {
@@ -86,7 +85,7 @@ private:
 
   df::DrapeEngineSafePtr m_drapeEngine;
 
-  boost::optional<ScreenBase> m_currentModelView;
+  std::optional<ScreenBase> m_currentModelView;
 
   std::vector<MwmSet::MwmId> m_lastMwms;
   mutable std::map<MwmSet::MwmId, Info> m_mwmCache;

--- a/map/notifications/notification_manager.hpp
+++ b/map/notifications/notification_manager.hpp
@@ -12,8 +12,6 @@
 #include <string>
 #include <unordered_set>
 
-#include <boost/optional.hpp>
-
 namespace ugc
 {
 class Api;


### PR DESCRIPTION
Последнее использование `boost::optional`. Везде используется `std::optional`,
а здесь почему-то остался `boost::optional`.