### PR TITLE
[drape] [shaders] [ios] Fix build with cmake

### DIFF
--- a/drape/CMakeLists.txt
+++ b/drape/CMakeLists.txt
@@ -135,9 +135,10 @@ append(
   hw_texture_ios.mm
   metal/metal_base_context.hpp
   metal/metal_base_context.mm
+  metal/metal_cleaner.hpp
+  metal/metal_cleaner.mm
   metal/metal_gpu_buffer_impl.mm
   metal/metal_gpu_program.hpp
-  metal/metal_mesh_object_impl.hpp
   metal/metal_mesh_object_impl.mm
   metal/metal_states.hpp
   metal/metal_states.mm

--- a/shaders/CMakeLists.txt
+++ b/shaders/CMakeLists.txt
@@ -141,7 +141,7 @@ if (PLATFORM_IPHONE)
   target_sources(
     ${PROJECT_NAME}
     PRIVATE
-      metal/debug_rect.metal
+      Metal/debug_rect.metal
       metal_program_params.hpp
       metal_program_params.mm
       metal_program_pool.hpp


### PR DESCRIPTION
При компиляции для iOS некоторые файлы упоминаемые в CMakeLists.txt отсуствуют,
и наоборот некоторые существующие не упоминаются.
Плюс исправление сборки для "чувствительной к регистру" файловой системы. 