### PR TITLE
[search] Query params minor refactoring.

### DIFF
--- a/search/geocoder.cpp
+++ b/search/geocoder.cpp
@@ -1778,10 +1778,10 @@ CBV Geocoder::RetrieveGeometryFeatures(MwmContext const & context, m2::RectD con
 {
   switch (id)
   {
-  case RectId::Pivot: return m_pivotRectsCache.Get(context, rect, m_params.GetScale());
-  case RectId::Postcode: return m_postcodesRectsCache.Get(context, rect, m_params.GetScale());
-  case RectId::Locality: return m_localityRectsCache.Get(context, rect, m_params.GetScale());
-  case RectId::Suburb: return m_localityRectsCache.Get(context, rect, m_params.GetScale());
+  case RectId::Pivot: return m_pivotRectsCache.Get(context, rect, m_params.m_scale);
+  case RectId::Postcode: return m_postcodesRectsCache.Get(context, rect, m_params.m_scale);
+  case RectId::Locality: return m_localityRectsCache.Get(context, rect, m_params.m_scale);
+  case RectId::Suburb: return m_localityRectsCache.Get(context, rect, m_params.m_scale);
   case RectId::Count: ASSERT(false, ("Invalid RectId.")); return CBV();
   }
   UNREACHABLE();

--- a/search/geocoder.hpp
+++ b/search/geocoder.hpp
@@ -94,6 +94,7 @@ public:
     std::shared_ptr<Tracer> m_tracer;
     double m_streetSearchRadiusM = 0.0;
     double m_villageSearchRadiusM = 0.0;
+    int m_scale = scales::GetUpperScale();
   };
 
   struct LocalitiesCaches

--- a/search/processor.cpp
+++ b/search/processor.cpp
@@ -755,7 +755,7 @@ void Processor::InitPreRanker(Geocoder::Params const & geocoderParams,
   params.m_viewport = GetViewport();
   params.m_accuratePivotCenter = GetPivotPoint(viewportSearch);
   params.m_position = m_position;
-  params.m_scale = geocoderParams.GetScale();
+  params.m_scale = geocoderParams.m_scale;
   params.m_limit = max(SearchParams::kPreResultsCount, searchParams.m_maxNumResults);
   params.m_viewportSearch = viewportSearch;
   params.m_categorialRequest = geocoderParams.IsCategorialRequest();

--- a/search/query_params.cpp
+++ b/search/query_params.cpp
@@ -60,7 +60,6 @@ void QueryParams::Clear()
   m_hasPrefix = false;
   m_typeIndices.clear();
   m_langs.Clear();
-  m_scale = scales::GetUpperScale();
 }
 
 bool QueryParams::IsCategorySynonym(size_t i) const { return !GetTypeIndices(i).empty(); }

--- a/search/query_params.hpp
+++ b/search/query_params.hpp
@@ -135,8 +135,6 @@ public:
   void SetCategorialRequest(bool isCategorial) { m_isCategorialRequest = isCategorial; }
   bool IsCategorialRequest() const { return m_isCategorialRequest; }
 
-  int GetScale() const { return m_scale; }
-
 private:
   friend std::string DebugPrint(QueryParams const & params);
 
@@ -153,6 +151,5 @@ private:
   std::vector<TypeIndices> m_typeIndices;
 
   Langs m_langs;
-  int m_scale = scales::GetUpperScale();
 };
 }  // namespace search


### PR DESCRIPTION
Не понятно почему m_scale в QueryParams, т.к. к запросу особо отношения не имеет.
Предлагаю или перенести в GeocoderParams или вообще выпилить и заменить на `scales::GetUpperScale()`, т.к. другие значения оно не принимает.