### PR TITLE
[routing] Routing integration test fix for 200920.

### DIFF
--- a/routing/routing_integration_tests/bicycle_route_test.cpp
+++ b/routing/routing_integration_tests/bicycle_route_test.cpp
@@ -131,7 +131,7 @@ UNIT_TEST(SwedenStockholmBicyclePastFerry)
   CalculateRouteAndTestRouteLength(
       GetVehicleComponents(VehicleType::Bicycle),
       mercator::FromLatLon(59.4725, 18.51355), {0.0, 0.0},
-      mercator::FromLatLon(59.32967, 18.075), 46163.7);
+      mercator::FromLatLon(59.42533, 18.35991), 14338.0);
 }
 
 // Test on cross mwm bicycle routing.

--- a/routing/routing_integration_tests/transit_route_test.cpp
+++ b/routing/routing_integration_tests/transit_route_test.cpp
@@ -44,7 +44,7 @@ UNIT_TEST(Transit_Moscow_NoSubwayTest)
                                   mercator::FromLatLon(55.73470, 37.62617));
   TEST_EQUAL(routeResult.second, RouterResultCode::NoError, ());
 
-  integration::TestRouteLength(*routeResult.first, 588.9);
+  integration::TestRouteLength(*routeResult.first, 612.7);
 
   CHECK(routeResult.first, ());
   integration::CheckSubwayAbsent(*routeResult.first);


### PR DESCRIPTION
После обновления карты https://github.com/mapsme/omim/pull/13747 сломалось 2 routing integration tests.

**SwedenStockholmBicyclePastFerry**
Данный тест на то, что велосипедные маршруты прокладываются через паромные переправы. В карте 200822 маршрут выглядел так:
![image](https://user-images.githubusercontent.com/1768114/94448938-2c113b80-01b4-11eb-9446-04ee2b6cff8b.png)
После обновления карты до 200920 он изменился:
![image](https://user-images.githubusercontent.com/1768114/94448987-3b908480-01b4-11eb-8736-0267164ad887.png)
И изменилась его длина. От этого сломался тест. Он попрежнему прокладывается через route=ferry, но поскольку обновились фичи:
https://www.openstreetmap.org/way/837464719
https://www.openstreetmap.org/way/220794601
Он стал прокладываться иным путем.

Я сократил маршрут, но сделал так что большая его часть лежит на фичах route=ferry. Теперь он выглядит так:
![image](https://user-images.githubusercontent.com/1768114/94449317-a0e47580-01b4-11eb-8e1e-b4eb8138dd7d.png)

**Transit_Moscow_NoSubwayTest**
Тест на то, что не стоит ехать на метро, а быстрее пройти пешком. Т.е. не смотря на то, что выбран маршрут transit мы прокладываем пеший. Было на 200822
![image](https://user-images.githubusercontent.com/1768114/94450849-6f6ca980-01b6-11eb-8d27-4823770f759d.png)
Стало на 200920
![image](https://user-images.githubusercontent.com/1768114/94450874-77c4e480-01b6-11eb-9b66-4048b295bfb5.png)
Здесь нужно просто поправить длину маршрута. То что все сегменты маршрута пешие (не проходят через метро), проверяется так же в этом тесте.

@mesozoic-drones @maksimandrianov PTAL