### PR TITLE
[search] Make search results more stable.

### DIFF
--- a/search/pre_ranker.cpp
+++ b/search/pre_ranker.cpp
@@ -263,7 +263,7 @@ void PreRanker::UpdateResults(bool lastUpdate)
   m_results.clear();
   m_ranker.UpdateResults(lastUpdate);
 
-  if (lastUpdate)
+  if (lastUpdate && !m_currEmit.empty())
     m_currEmit.swap(m_prevEmit);
 }
 

--- a/search/pre_ranker.cpp
+++ b/search/pre_ranker.cpp
@@ -39,11 +39,12 @@ void SweepNearbyResults(double xEps, double yEps, set<FeatureID> const & prevEmi
     auto const & p = results[i].GetInfo().m_center;
     uint8_t const rank = results[i].GetInfo().m_rank;
     uint8_t const popularity = results[i].GetInfo().m_popularity;
-    uint8_t const prevCount = prevEmit.count(results[i].GetId()) ? 1 : 0;
     uint8_t const exactMatch = results[i].GetInfo().m_exactMatch ? 1 : 0;
-    // We prefer result which passed the filter even if it has lower rank / popularity / prevCount /
-    // exactMatch.
+    // We prefer result which passed the filter even if it has lower rank / popularity / exactMatch.
     uint8_t const filterPassed = results[i].GetInfo().m_refusedByFilter ? 0 : 2;
+    // We prefer result from prevEmit over result with better filterPassed because otherwise we have
+    // lots of blinking results.
+    uint8_t const prevCount = prevEmit.count(results[i].GetId()) == 0 ? 0 : 3;
     uint8_t const priority = max({rank, prevCount, popularity, exactMatch}) + filterPassed;
     sweeper.Add(p.x, p.y, i, priority);
   }

--- a/search/pre_ranker.hpp
+++ b/search/pre_ranker.hpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <limits>
 #include <optional>
 #include <random>
 #include <set>
@@ -47,7 +48,9 @@ public:
 
     int m_scale = 0;
 
-    size_t m_batchSize = 100;
+    // Batch size for Everywhere search mode. For viewport search we limit search results number
+    // with SweepNearbyResults.
+    size_t m_everywhereBatchSize = 100;
 
     // The maximum total number of results to be emitted in all batches.
     size_t m_limit = 0;
@@ -87,7 +90,11 @@ public:
   void UpdateResults(bool lastUpdate);
 
   size_t Size() const { return m_results.size() + m_relaxedResults.size(); }
-  size_t BatchSize() const { return m_params.m_batchSize; }
+  size_t BatchSize() const
+  {
+    return m_params.m_viewportSearch ? std::numeric_limits<size_t>::max()
+                                     : m_params.m_everywhereBatchSize;
+  }
   size_t NumSentResults() const { return m_numSentResults; }
   bool HaveFullyMatchedResult() const { return m_haveFullyMatchedResult; }
   size_t Limit() const { return m_params.m_limit; }

--- a/search/search_integration_tests/pre_ranker_test.cpp
+++ b/search/search_integration_tests/pre_ranker_test.cpp
@@ -141,9 +141,9 @@ UNIT_CLASS_TEST(PreRankerTest, Smoke)
   params.m_viewport = kViewport;
   params.m_accuratePivotCenter = kPivot;
   params.m_scale = scales::GetUpperScale();
-  params.m_batchSize = kBatchSize;
+  params.m_everywhereBatchSize = kBatchSize;
   params.m_limit = pois.size();
-  params.m_viewportSearch = true;
+  params.m_viewportSearch = false;
   preRanker.Init(params);
 
   vector<double> distances(pois.size());


### PR DESCRIPTION
1) При поиске во вьюпорте при скролле периодически происходит отмена не завершенного поиска после чего приходят пустые результаты, которые могут затирать m_prevEmit, в результате чего стабильность результатов страдает.

2) После ограничения результатов на карте через прореживание (SweepNearbyResults) их остаётся не слишком много, нет особой необходимости в уменьшении количества результатов до BatchSize. При уменьшении до BatchSize может страдать стабильность результатов -- в SweepNearbyResults результаты выбираются с учётом их присутствия в m_prevEmit. Если после этого результат будет выкинут при фильтрации по BatchSize, то дальше он не попадёт в m_prevEmit и будет мигать.

3) Лучше выглядит когда мы предпочитаем результаты из прошлой выдачи результатам прошедшим фильтры. На кол-во результатов прошедших фильтры это не сильно влияет, т.к. изначально результаты выбираются с учётом фильтров, но мигания становится существенно меньше.