### PR TITLE
[pybindings] Fix linking on Mac

### DIFF
--- a/generator/mwm_diff/pymwm_diff/CMakeLists.txt
+++ b/generator/mwm_diff/pymwm_diff/CMakeLists.txt
@@ -22,4 +22,8 @@ omim_link_libraries(
   ${LIBZ}
 )
 
+if (PLATFORM_MAC)
+  omim_link_libraries(${PROJECT_NAME} "-Wl,-undefined,dynamic_lookup")
+endif()
+
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")

--- a/generator/pygen/CMakeLists.txt
+++ b/generator/pygen/CMakeLists.txt
@@ -50,4 +50,8 @@ omim_link_libraries(
 link_qt5_core(${PROJECT_NAME})
 link_qt5_network(${PROJECT_NAME})
 
+if (PLATFORM_MAC)
+  omim_link_libraries(${PROJECT_NAME} "-Wl,-undefined,dynamic_lookup")
+endif()
+
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")

--- a/kml/pykmlib/CMakeLists.txt
+++ b/kml/pykmlib/CMakeLists.txt
@@ -32,7 +32,7 @@ omim_link_libraries(
 link_qt5_core(${PROJECT_NAME})
 
 if (PLATFORM_MAC)
-  omim_link_libraries(${PROJECT_NAME} ${LIBZ})
+  omim_link_libraries(${PROJECT_NAME} "-Wl,-undefined,dynamic_lookup")
 endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")

--- a/local_ads/pylocal_ads/CMakeLists.txt
+++ b/local_ads/pylocal_ads/CMakeLists.txt
@@ -16,4 +16,8 @@ omim_link_libraries(
   base
 )
 
+if (PLATFORM_MAC)
+  omim_link_libraries(${PROJECT_NAME} "-Wl,-undefined,dynamic_lookup")
+endif()
+
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")

--- a/search/pysearch/CMakeLists.txt
+++ b/search/pysearch/CMakeLists.txt
@@ -39,4 +39,8 @@ omim_link_libraries(
 link_qt5_core(${PROJECT_NAME})
 link_qt5_network(${PROJECT_NAME})
 
+if (PLATFORM_MAC)
+  omim_link_libraries(${PROJECT_NAME} "-Wl,-undefined,dynamic_lookup")
+endif()
+
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")

--- a/tracking/pytracking/CMakeLists.txt
+++ b/tracking/pytracking/CMakeLists.txt
@@ -9,5 +9,17 @@ include_directories(${CMAKE_BINARY_DIR})
 
 omim_add_library(${PROJECT_NAME} MODULE ${SRC})
 
-omim_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} tracking coding geometry base)
+omim_link_libraries(
+    ${PROJECT_NAME} 
+    ${Boost_LIBRARIES}
+    tracking
+    coding
+    geometry
+    base
+)
+
+if (PLATFORM_MAC)
+    omim_link_libraries(${PROJECT_NAME} "-Wl,-undefined,dynamic_lookup")
+endif()
+
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")

--- a/traffic/pytraffic/CMakeLists.txt
+++ b/traffic/pytraffic/CMakeLists.txt
@@ -14,6 +14,7 @@ if (PLATFORM_MAC)
     ${PROJECT_NAME}
     ${Qt5Widgets_LIBRARIES}
     "-framework QuartzCore"
+    "-Wl,-undefined,dynamic_lookup"
   )
 endif()
 


### PR DESCRIPTION
Mac has different linker defaults than linux, and by default it
does not allow undefined symbols to be left in resulting pybinding
library.
To allow it, we specifically pass linker argument when linking final
pybinding object.

This is done to avoid linking excessively to libpythonX.Y since at the
time pybinding is loaded into Python process, all libpython symbols
would be immediately available.

Problem was introduced in #13695, after which all Mac pybindings builds were broken.

References:
Linux: https://linux.die.net/man/1/ld, section
```
--allow-shlib-undefined
--no-allow-shlib-undefined
Allows or disallows undefined symbols in shared libraries. This switch is similar to --no-undefined except that it determines the behaviour when the undefined symbols are in a shared library rather than a regular object file. It does not affect how undefined symbols in regular object files are handled.
The default behaviour is to report errors for any undefined symbols referenced in shared libraries if the linker is being used to create an executable, but to allow them if the linker is being used to create a shared library.

The reasons for allowing undefined symbol references in shared libraries specified at link time are that:

- A shared library specified at link time may not be the same as the one that is available at load time, so the symbol might actually be resolvable at load time.
- There are some operating systems, eg BeOS and HPPA , where undefined symbols in shared libraries are normal.

The BeOS kernel for example patches shared libraries at load time to select whichever function is most appropriate for the current architecture. This is used, for example, to dynamically select an appropriate memset function.
```
MacOS: https://www.unix.com/man-page/osx/1/ld/, section
```
   Two-level namespace
     By default all references resolved to a dynamic library record the library to which they were resolved. At runtime, dyld uses that informa-
     tion to directly resolve symobls.	The alternative is to use the -flat_namespace option.  With flat namespace, the library is not recorded.
     At runtime, dyld will search each dynamic library in load order when resolving symbols. This is slower, but more like how other operating
     systems resolve symbols.
...
   Dynamic libraries undefines
     When linking for two-level namespace, ld does not verify that undefines in dylibs actually exist.	But when linking for flat namespace, ld
     does check that all undefines from all loaded dylibs have a matching definition.  This is sometimes used to force selected functions to be
     loaded from a static library.
...
     -undefined treatment
		 Specifies how undefined symbols are to be treated. Options are: error, warning, suppress, or dynamic_lookup.  The default is
		 error.
```
Somehow currently on Mac our linking is forced to be for flat namespace, and we can't avoid check for all symbols to be defined.
Option ``-undefined dynamic_lookup`` eases this check and allows linking to succeed.
Alternative would be to try to use option ``-bundle_loader``, but that might be much more complicated.