### PR TITLE
[qt][map] Visualize routing turns on the map (desktop app).

### DIFF
--- a/map/routing_manager.hpp
+++ b/map/routing_manager.hpp
@@ -214,6 +214,18 @@ public:
   {
     return m_routingSession.GetTurnNotificationsLocale();
   }
+  // @return polyline of the route.
+  routing::FollowedPolyline const & GetRoutePolylineForTests() const
+  {
+    return m_routingSession.GetRouteForTests()->GetFollowedPolyline();
+  }
+  // @return generated turns on the route.
+  std::vector<routing::turns::TurnItem> GetTurnsOnRouteForTests() const
+  {
+    std::vector<routing::turns::TurnItem> turns;
+    m_routingSession.GetRouteForTests()->GetTurnsForTesting(turns);
+    return turns;
+  }
   /// \brief Adds to @param notifications strings - notifications, which are ready to be
   /// pronounced to end user right now.
   /// Adds notifications about turns and speed camera on the road.

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -54,6 +54,8 @@ set(
   preferences_dialog.hpp
   routing_settings_dialog.cpp
   routing_settings_dialog.hpp
+  routing_turns_visualizer.cpp
+  routing_turns_visualizer.hpp
   ruler.cpp
   ruler.hpp
   screenshoter.cpp

--- a/qt/draw_widget.cpp
+++ b/qt/draw_widget.cpp
@@ -8,9 +8,9 @@
 #include "qt/routing_settings_dialog.hpp"
 #include "qt/screenshoter.hpp"
 
-#include "map/framework.hpp"
-
 #include "generator/borders.hpp"
+
+#include "map/framework.hpp"
 
 #include "search/result.hpp"
 #include "search/reverse_geocoder.hpp"
@@ -32,22 +32,19 @@
 #include "base/assert.hpp"
 #include "base/file_name_utils.hpp"
 
-#include <string>
-#include <vector>
+#include "defines.hpp"
 
-#include <QtGui/QMouseEvent>
+#include <QtCore/QThread>
+#include <QtCore/QTimer>
 #include <QtGui/QGuiApplication>
-
+#include <QtGui/QMouseEvent>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QDesktopWidget>
 #include <QtWidgets/QDialogButtonBox>
 #include <QtWidgets/QMenu>
 
-#include <QtCore/QLocale>
-#include <QtCore/QThread>
-#include <QtCore/QTimer>
-
-#include "defines.hpp"
+#include <string>
+#include <vector>
 
 using namespace qt::common;
 
@@ -96,14 +93,20 @@ DrawWidget::DrawWidget(Framework & framework, bool apiOpenGLES3, std::unique_ptr
   m_framework.SetPlacePageListeners([this]() { ShowPlacePage(); },
                                     {} /* onClose */, {} /* onUpdate */);
 
-  m_framework.GetRoutingManager().SetRouteBuildingListener(
-      [](routing::RouterResultCode, storage::CountriesSet const &) {});
+  auto & routingManager = m_framework.GetRoutingManager();
 
-  m_framework.GetRoutingManager().SetRouteRecommendationListener(
-    [this](RoutingManager::Recommendation r)
-  {
-    OnRouteRecommendation(r);
-  });
+  routingManager.SetRouteBuildingListener(
+      [&routingManager, this](routing::RouterResultCode, storage::CountriesSet const &) {
+        auto & drapeApi = m_framework.GetDrapeApi();
+
+        m_turnsVisualizer.ClearTurns(drapeApi);
+
+        if (RoutingSettings::TurnsEnabled())
+          m_turnsVisualizer.Visualize(routingManager, drapeApi);
+      });
+
+  routingManager.SetRouteRecommendationListener(
+      [this](RoutingManager::Recommendation r) { OnRouteRecommendation(r); });
 
   m_framework.SetCurrentCountryChangedListener([this](storage::CountryId const & countryId) {
     m_countryId = countryId;
@@ -578,7 +581,9 @@ void DrawWidget::SubmitRoutingPoint(m2::PointD const & pt)
   routingManager.AddRoutePoint(std::move(point));
 
   if (routingManager.GetRoutePoints().size() >= 2)
+  {
     routingManager.BuildRoute();
+  }
 }
 
 void DrawWidget::SubmitBookmark(m2::PointD const & pt)
@@ -626,6 +631,8 @@ void DrawWidget::ClearRoute()
     else if (style == MapStyle::MapStyleVehicleDark)
       SetMapStyle(MapStyle::MapStyleDark);
   }
+
+  m_turnsVisualizer.ClearTurns(m_framework.GetDrapeApi());
 }
 
 void DrawWidget::OnRouteRecommendation(RoutingManager::Recommendation recommendation)

--- a/qt/draw_widget.hpp
+++ b/qt/draw_widget.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "qt/qt_common/map_widget.hpp"
+#include "qt/routing_turns_visualizer.hpp"
 #include "qt/ruler.hpp"
 
 #include "map/everywhere_search_params.hpp"
@@ -11,9 +12,10 @@
 
 #include "routing/router.hpp"
 
+#include "drape_frontend/drape_engine.hpp"
 #include "drape_frontend/gui/skin.hpp"
 
-#include "drape_frontend/drape_engine.hpp"
+#include <QtWidgets/QRubberBand>
 
 #include <condition_variable>
 #include <functional>
@@ -21,8 +23,6 @@
 #include <mutex>
 #include <optional>
 #include <string>
-
-#include <QtWidgets/QRubberBand>
 
 class Framework;
 
@@ -150,5 +150,6 @@ private:
 
   std::unique_ptr<Screenshoter> m_screenshoter;
   Ruler m_ruler;
+  RoutingTurnsVisualizer m_turnsVisualizer;
 };
 }  // namespace qt

--- a/qt/routing_settings_dialog.cpp
+++ b/qt/routing_settings_dialog.cpp
@@ -22,10 +22,19 @@ char constexpr kDelim[] = " ,\t";
 
 namespace qt
 {
+std::string const RoutingSettings::kShowTurnsSettings = "show_turns_desktop";
 std::string const RoutingSettings::kUseCachedRoutingSettings = "use_cached_settings_desktop";
 std::string const RoutingSettings::kStartCoordsCachedSettings = "start_coords_desktop";
 std::string const RoutingSettings::kFinishCoordsCachedSettings = "finish_coords_desktop";
 std::string const RoutingSettings::kRouterTypeCachedSettings = "router_type_desktop";
+
+// static
+bool RoutingSettings::TurnsEnabled()
+{
+  bool enabled = false;
+  settings::Get(kShowTurnsSettings, enabled);
+  return enabled;
+}
 
 // static
 bool RoutingSettings::IsCacheEnabled()
@@ -83,13 +92,14 @@ void RoutingSettings::LoadSettings(Framework & framework)
 }
 
 RoutingSettings::RoutingSettings(QWidget * parent, Framework & framework)
-  : QDialog(parent),
-    m_framework(framework),
-    m_form(this),
-    m_startInput(new QLineEdit(this)),
-    m_finishInput(new QLineEdit(this)),
-    m_routerType(new QComboBox(this)),
-    m_alwaysCheckbox(new QCheckBox("", this))
+  : QDialog(parent)
+  , m_framework(framework)
+  , m_form(this)
+  , m_startInput(new QLineEdit(this))
+  , m_finishInput(new QLineEdit(this))
+  , m_routerType(new QComboBox(this))
+  , m_showTurnsCheckbox(new QCheckBox("", this))
+  , m_alwaysCheckbox(new QCheckBox("", this))
 {
   setWindowTitle("Routing settings");
 
@@ -121,6 +131,7 @@ void RoutingSettings::AddLineEdit(std::string const & title, QLineEdit * lineEdi
 
 void RoutingSettings::AddCheckBox()
 {
+  m_form.addRow("Show turns:", m_showTurnsCheckbox);
   m_form.addRow("Save for next sessions:", m_alwaysCheckbox);
 }
 
@@ -173,6 +184,7 @@ bool RoutingSettings::ValidateAndSaveCoordsFromInput()
 
 void RoutingSettings::SaveSettings()
 {
+  settings::Set(kShowTurnsSettings, m_showTurnsCheckbox->checkState() == Qt::CheckState::Checked);
   settings::Set(kUseCachedRoutingSettings, true);
   ValidateAndSaveCoordsFromInput();
   settings::Set(kRouterTypeCachedSettings, m_routerType->currentIndex());
@@ -193,6 +205,10 @@ void RoutingSettings::LoadSettings()
   m_routerType->setCurrentIndex(routerType);
 
   m_framework.GetRoutingManager().SetRouterImpl(static_cast<routing::RouterType>(routerType));
+
+  bool showTurns = false;
+  settings::TryGet(kShowTurnsSettings, showTurns);
+  m_showTurnsCheckbox->setChecked(showTurns);
 
   bool setChecked = false;
   settings::TryGet(kUseCachedRoutingSettings, setChecked);

--- a/qt/routing_settings_dialog.hpp
+++ b/qt/routing_settings_dialog.hpp
@@ -20,6 +20,8 @@ class RoutingSettings : public QDialog
 {
 public:
   static bool IsCacheEnabled();
+  static bool TurnsEnabled();
+
   static std::optional<ms::LatLon> GetCoords(bool start);
   static void LoadSettings(Framework & framework);
   static void ResetSettings();
@@ -29,6 +31,7 @@ public:
   void ShowModal();
 
 private:
+  static std::string const kShowTurnsSettings;
   static std::string const kUseCachedRoutingSettings;
   static std::string const kStartCoordsCachedSettings;
   static std::string const kFinishCoordsCachedSettings;
@@ -54,6 +57,7 @@ private:
   QLineEdit * m_finishInput;
 
   QComboBox * m_routerType;
+  QCheckBox * m_showTurnsCheckbox;
   QCheckBox * m_alwaysCheckbox;
 };
 }  // namespace qt

--- a/qt/routing_turns_visualizer.cpp
+++ b/qt/routing_turns_visualizer.cpp
@@ -1,0 +1,43 @@
+#include "qt/routing_turns_visualizer.hpp"
+
+namespace qt
+{
+void RoutingTurnsVisualizer::Visualize(RoutingManager & routingManager, df::DrapeApi & drape)
+{
+  auto const & polyline = routingManager.GetRoutePolylineForTests().GetPolyline();
+  auto const & turns = routingManager.GetTurnsOnRouteForTests();
+
+  for (auto const & turn : turns)
+  {
+    std::string const id = GetId(turn);
+
+    m_turnIds.insert(id);
+    m2::PointD const & turnPoint = polyline.GetPoint(turn.m_index);
+
+    std::vector<m2::PointD> const fakePoly = {turnPoint, turnPoint};
+    static dp::Color const orangeColor = dp::Color(242, 138, 2, 255);
+
+    drape.AddLine(
+        id, df::DrapeApiLineData(fakePoly, orangeColor).Width(7.0f).ShowPoints(true).ShowId());
+  }
+}
+
+void RoutingTurnsVisualizer::ClearTurns(df::DrapeApi & drape)
+{
+  for (auto const & turnId : m_turnIds)
+    drape.RemoveLine(turnId);
+
+  m_turnIds.clear();
+}
+
+static std::string RoutingTurnsVisualizer::GetId(routing::turns::TurnItem const & turn)
+{
+  std::string const maneuver = turn.m_pedestrianTurn == routing::turns::PedestrianDirection::None
+                                   ? DebugPrint(turn.m_turn)
+                                   : DebugPrint(turn.m_pedestrianTurn);
+
+  std::string const index = std::to_string(turn.m_index);
+
+  return index + " " + maneuver;
+}
+}  // namespace qt

--- a/qt/routing_turns_visualizer.cpp
+++ b/qt/routing_turns_visualizer.cpp
@@ -30,7 +30,7 @@ void RoutingTurnsVisualizer::ClearTurns(df::DrapeApi & drape)
   m_turnIds.clear();
 }
 
-static std::string RoutingTurnsVisualizer::GetId(routing::turns::TurnItem const & turn)
+std::string RoutingTurnsVisualizer::GetId(routing::turns::TurnItem const & turn)
 {
   std::string const maneuver = turn.m_pedestrianTurn == routing::turns::PedestrianDirection::None
                                    ? DebugPrint(turn.m_turn)

--- a/qt/routing_turns_visualizer.hpp
+++ b/qt/routing_turns_visualizer.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "map/routing_manager.hpp"
+
+#include "routing/turns.hpp"
+
+#include "drape_frontend/drape_api.hpp"
+#include "drape_frontend/drape_engine.hpp"
+
+#include "geometry/point2d.hpp"
+
+#include <string>
+#include <unordered_set>
+
+namespace qt
+{
+class RoutingTurnsVisualizer
+{
+public:
+  // Shows routing turns on the map with its titles.
+  void Visualize(RoutingManager & routingManager, df::DrapeApi & drape);
+
+  // Removes turns from the map.
+  void ClearTurns(df::DrapeApi & drape);
+
+private:
+  // Returns turn id consisting of its index on the polyline and the maneuver name.
+  static std::string GetId(routing::turns::TurnItem const & turn);
+
+  // Turn ids for rendering on the map and erasing by drape.
+  std::unordered_set<std::string> m_turnIds;
+};
+}  // namespace qt


### PR DESCRIPTION
Реквест "страшненько, но удобно": в desktop-версию приложения добавлена возможность отображать координаты и названия маневров на построенном маршруте. 

**Зачем нужен этот реквест:** чтобы упростить проверку гипотез об алгоритмах генерации маршрутов, а также поиск и фикс багов.

**1. В настройки роутинга добавлен чекбокс, чтобы можно было включать/выключать визуализацию маневров.**
До реквеста | После реквеста |
--- | --- 
<img width="363" alt="Screenshot 2020-10-07 at 13 54 27" src="https://user-images.githubusercontent.com/54934129/95340351-b5fc8b00-08bd-11eb-8a02-98d118df83e1.png"> |  <img width="410" alt="Screenshot 2020-10-07 at 14 55 40" src="https://user-images.githubusercontent.com/54934129/95340386-c1e84d00-08bd-11eb-834d-42543c49a06d.png">


**2. Если чекбокс включен, помимо самого маршрута на карте появляются маневры.** Это точки - координаты на построенном маршруте и рядом с ними "названия" маневров. Название - это индекс на полилинии маршрута + тип маневра (направо, держитесь левее и тд).

<img width="600" alt="Screenshot 2020-10-07 at 16 51 17" src="https://user-images.githubusercontent.com/54934129/95340489-e6442980-08bd-11eb-9145-bdc71e69d0b9.png">

<img width="600" alt="Screenshot 2020-10-07 at 16 51 54" src="https://user-images.githubusercontent.com/54934129/95340514-ed6b3780-08bd-11eb-95b6-c401c42475d8.png">

<img width="600" alt="Screenshot 2020-10-07 at 16 52 21" src="https://user-images.githubusercontent.com/54934129/95340539-f65c0900-08bd-11eb-94d3-822a5124f0c1.png">