### PR TITLE
[adnroid] increase targetSdk and compileSdk to 29 api

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -65,6 +65,7 @@
       android:theme="@style/MwmTheme"
       android:supportsRtl="false"
       android:networkSecurityConfig="@xml/network_security_config"
+      android:requestLegacyExternalStorage="true"
       tools:replace="android:supportsRtl"
       tools:ignore="UnusedAttribute">
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,6 @@
 propMinSdkVersion=21
-propTargetSdkVersion=28
-propCompileSdkVersion=28
+propTargetSdkVersion=29
+propCompileSdkVersion=29
 propBuildToolsVersion=27.0.3
 propVersionCode=1030
 propVersionName=10.3.0


### PR DESCRIPTION
поднял версии апи до 29, добавил флаг в манифест для обхода проблемы с external storage как временное решение
