### PR TITLE
[routing] Custom turn constants for each vehicle type.

### DIFF
--- a/routing/car_directions.cpp
+++ b/routing/car_directions.cpp
@@ -58,8 +58,10 @@ bool CarDirectionsEngine::Generate(IndexRoadGraph const & graph,
     return false;
 
   RoutingEngineResult resultGraph(routeEdges, m_adjacentEdges, m_pathSegments);
-  auto const res = MakeTurnAnnotation(resultGraph, *m_numMwmIds, cancellable, routeGeometry, turns,
-                                      streetNames, segments);
+  CHECK_NOT_EQUAL(m_vehicleType, VehicleType::Count, (m_vehicleType));
+
+  auto const res = MakeTurnAnnotation(resultGraph, *m_numMwmIds, m_vehicleType, cancellable,
+                                      routeGeometry, turns, streetNames, segments);
 
   if (res != RouterResultCode::NoError)
     return false;

--- a/routing/directions_engine.hpp
+++ b/routing/directions_engine.hpp
@@ -5,6 +5,7 @@
 #include "routing/road_point.hpp"
 #include "routing/route.hpp"
 #include "routing/segment.hpp"
+#include "routing/vehicle_mask.hpp"
 
 #include "traffic/traffic_info.hpp"
 
@@ -44,7 +45,7 @@ public:
                         std::vector<Segment> & segments) = 0;
   void Clear();
 
-  void SetIsTransit(bool isTransit) { m_isTransit = isTransit; }
+  void SetVehicleType(VehicleType const & vehicleType) { m_vehicleType = vehicleType; }
 
 protected:
   FeaturesLoaderGuard & GetLoader(MwmSet::MwmId const & id);
@@ -70,6 +71,6 @@ protected:
   DataSource const & m_dataSource;
   std::shared_ptr<NumMwmIds> m_numMwmIds;
   std::unique_ptr<FeaturesLoaderGuard> m_loader;
-  bool m_isTransit = false;
+  VehicleType m_vehicleType = VehicleType::Count;
 };
 }  // namespace routing

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -1497,7 +1497,7 @@ RouterResultCode IndexRouter::RedressRoute(vector<Segment> const & segments,
 
   CHECK(m_directionsEngine, ());
 
-  m_directionsEngine->SetIsTransit(m_vehicleType == VehicleType::Transit);
+  m_directionsEngine->SetVehicleType(m_vehicleType);
   ReconstructRoute(*m_directionsEngine, roadGraph, m_trafficStash, cancellable, junctions,
                    move(times), route);
 

--- a/routing/pedestrian_directions.cpp
+++ b/routing/pedestrian_directions.cpp
@@ -35,7 +35,9 @@ bool PedestrianDirectionsEngine::Generate(IndexRoadGraph const & graph,
 
   vector<Edge> routeEdges;
 
-  if (m_isTransit)
+  CHECK_NOT_EQUAL(m_vehicleType, VehicleType::Count, (m_vehicleType));
+
+  if (m_vehicleType == VehicleType::Transit)
   {
     routeGeometry = path;
     graph.GetRouteSegments(segments);
@@ -65,8 +67,9 @@ bool PedestrianDirectionsEngine::Generate(IndexRoadGraph const & graph,
     return false;
 
   RoutingEngineResult resultGraph(routeEdges, m_adjacentEdges, m_pathSegments);
-  auto const res = MakeTurnAnnotationPedestrian(resultGraph, *m_numMwmIds, cancellable,
-                                                routeGeometry, turns, streetNames, segments);
+  auto const res =
+      MakeTurnAnnotationPedestrian(resultGraph, *m_numMwmIds, m_vehicleType, cancellable,
+                                   routeGeometry, turns, streetNames, segments);
 
   if (res != RouterResultCode::NoError)
     return false;

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -418,11 +418,12 @@ UNIT_TEST(RussiaMoscowHydroprojectBridgeCrossing)
 
   std::vector<turns::TurnItem> t;
   route.GetTurnsForTesting(t);
-  TEST_EQUAL(t.size(), 3, ());
+  TEST_EQUAL(t.size(), 4, ());
 
   TEST_EQUAL(t[0].m_pedestrianTurn, PedestrianDirection::TurnLeft, ());
-  TEST_EQUAL(t[1].m_pedestrianTurn, PedestrianDirection::TurnRight, ());
-  TEST_EQUAL(t[2].m_pedestrianTurn, PedestrianDirection::ReachedYourDestination, ());
+  TEST_EQUAL(t[1].m_pedestrianTurn, PedestrianDirection::TurnLeft, ());
+  TEST_EQUAL(t[2].m_pedestrianTurn, PedestrianDirection::TurnRight, ());
+  TEST_EQUAL(t[3].m_pedestrianTurn, PedestrianDirection::ReachedYourDestination, ());
 }
 
 UNIT_TEST(BelarusMinskRenaissanceHotelUndergroundCross)

--- a/routing/routing_settings.cpp
+++ b/routing/routing_settings.cpp
@@ -9,8 +9,11 @@ namespace routing
 // RoutingSettings ---------------------------------------------------------------------------------
 RoutingSettings::RoutingSettings(bool useDirectionForRouteBuilding, bool matchRoute,
                                  bool soundDirection, double matchingThresholdM,
-                                 bool showTurnAfterNext,
-                                 double minSpeedForRouteRebuildMpS, double finishToleranceM)
+                                 bool showTurnAfterNext, double minSpeedForRouteRebuildMpS,
+                                 double finishToleranceM, size_t maxOutgoingPointsCount,
+                                 double minOutgoingDistMeters, size_t maxIngoingPointsCount,
+                                 double minIngoingDistMeters, size_t notSoCloseMaxPointsCount,
+                                 double notSoCloseMaxDistMeters)
 
   : m_useDirectionForRouteBuilding(useDirectionForRouteBuilding)
   , m_matchRoute(matchRoute)
@@ -19,6 +22,12 @@ RoutingSettings::RoutingSettings(bool useDirectionForRouteBuilding, bool matchRo
   , m_showTurnAfterNext(showTurnAfterNext)
   , m_minSpeedForRouteRebuildMpS(minSpeedForRouteRebuildMpS)
   , m_finishToleranceM(finishToleranceM)
+  , m_maxOutgoingPointsCount(maxOutgoingPointsCount)
+  , m_minOutgoingDistMeters(minOutgoingDistMeters)
+  , m_maxIngoingPointsCount(maxIngoingPointsCount)
+  , m_minIngoingDistMeters(minIngoingDistMeters)
+  , m_notSoCloseMaxPointsCount(notSoCloseMaxPointsCount)
+  , m_notSoCloseMaxDistMeters(notSoCloseMaxDistMeters)
 {
 }
 
@@ -33,7 +42,13 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
             20.0 /* m_matchingThresholdM */,
             false /* m_showTurnAfterNext */,
             -1 /* m_minSpeedForRouteRebuildMpS */,
-            15.0 /* m_finishToleranceM */};
+            15.0 /* m_finishToleranceM */,
+            6 /* m_maxOutgoingPointsCount */,
+            5.0 /* m_minOutgoingDistMeters */,
+            2 /* m_maxIngoingPointsCount */,
+            4.0 /* m_minIngoingDistMeters */,
+            3 /* m_notSoCloseMaxPointsCount */,
+            25.0 /* m_notSoCloseMaxDistMeters */};
   case VehicleType::Transit:
     return {false /* useDirectionForRouteBuilding */,
             true /* m_matchRoute */,
@@ -41,7 +56,13 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
             40.0 /* m_matchingThresholdM */,
             false /* m_showTurnAfterNext */,
             -1 /* m_minSpeedForRouteRebuildMpS */,
-            15.0 /* m_finishToleranceM */};
+            15.0 /* m_finishToleranceM */,
+            6 /* m_maxOutgoingPointsCount */,
+            5.0 /* m_minOutgoingDistMeters */,
+            2 /* m_maxIngoingPointsCount */,
+            4.0 /* m_minIngoingDistMeters */,
+            3 /* m_notSoCloseMaxPointsCount */,
+            25.0 /* m_notSoCloseMaxDistMeters */};
   case VehicleType::Bicycle:
     return {false /* useDirectionForRouteBuilding */,
             true /* m_matchRoute */,
@@ -49,7 +70,13 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
             30.0 /* m_matchingThresholdM */,
             false /* m_showTurnAfterNext */,
             -1 /* m_minSpeedForRouteRebuildMpS */,
-            15.0 /* m_finishToleranceM */};
+            15.0 /* m_finishToleranceM */,
+            9 /* m_maxOutgoingPointsCount */,
+            90.0 /* m_minOutgoingDistMeters */,
+            2 /* m_maxIngoingPointsCount */,
+            70.0 /* m_minIngoingDistMeters */,
+            3 /* m_notSoCloseMaxPointsCount */,
+            25.0 /* m_notSoCloseMaxDistMeters */};
   case VehicleType::Car:
     return {true /* useDirectionForRouteBuilding */,
             true /* m_matchRoute */,
@@ -57,7 +84,13 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
             50.0 /* m_matchingThresholdM */,
             true /* m_showTurnAfterNext */,
             routing::KMPH2MPS(3.0) /* m_minSpeedForRouteRebuildMpS */,
-            20.0 /* m_finishToleranceM */};
+            20.0 /* m_finishToleranceM */,
+            9 /* m_maxOutgoingPointsCount */,
+            120.0 /* m_minOutgoingDistMeters */,
+            2 /* m_maxIngoingPointsCount */,
+            100.0 /* m_minIngoingDistMeters */,
+            3 /* m_notSoCloseMaxPointsCount */,
+            30.0 /* m_notSoCloseMaxDistMeters */};
   case VehicleType::Count:
     CHECK(false, ("Can't create GetRoutingSettings for", vehicleType));
   }

--- a/routing/routing_settings.hpp
+++ b/routing/routing_settings.hpp
@@ -14,8 +14,10 @@ struct RoutingSettings
 private:
   RoutingSettings(bool useDirectionForRouteBuilding, bool matchRoute, bool soundDirection,
                   double matchingThresholdM, bool showTurnAfterNext,
-                  double minSpeedForRouteRebuildMpS, double finishToleranceM);
-
+                  double minSpeedForRouteRebuildMpS, double finishToleranceM,
+                  size_t maxOutgoingPointsCount, double minOutgoingDistMeters,
+                  size_t maxIngoingPointsCount, double minIngoingDistMeters,
+                  size_t notSoCloseMaxPointsCount, double notSoCloseMaxDistMeters);
 
 public:
   /// \brief We accumulate several positions to calculate current direction.
@@ -47,6 +49,18 @@ public:
 
   /// \brief The distance to the route finish point at which the route should be completed.
   double m_finishToleranceM;
+
+  // These 4 parameters are used during turns generation to calculate the turn angle. Based on these
+  // parameters, the point before the turn and the point after the turn are determined, and the
+  // angle between them is calculated.
+  size_t m_maxOutgoingPointsCount;
+  double m_minOutgoingDistMeters;
+  size_t m_maxIngoingPointsCount;
+  double m_minIngoingDistMeters;
+  // These 2 parameters are used during turns generation to calculate the angle between the turn
+  // point and one of the neighbour points to find out if the route turns significantly or not.
+  size_t m_notSoCloseMaxPointsCount;
+  double m_notSoCloseMaxDistMeters;
 };
 
 RoutingSettings GetRoutingSettings(VehicleType vehicleType);

--- a/routing/routing_tests/turns_generator_test.cpp
+++ b/routing/routing_tests/turns_generator_test.cpp
@@ -404,18 +404,24 @@ UNIT_TEST(TestCheckUTurnOnRoute)
   pathSegments[3].m_path.clear();
 
   RoutingResultTest resultTest(pathSegments);
-
+  RoutingSettings const vehicleSettings = GetRoutingSettings(VehicleType::Car);
   // Zigzag test.
   TurnItem turn1;
-  TEST_EQUAL(CheckUTurnOnRoute(resultTest, 1 /* outgoingSegmentIndex */, NumMwmIds(), turn1), 1, ());
+  TEST_EQUAL(CheckUTurnOnRoute(resultTest, 1 /* outgoingSegmentIndex */, NumMwmIds(),
+                               vehicleSettings, turn1),
+             1, ());
   TEST_EQUAL(turn1.m_turn, CarDirection::UTurnLeft, ());
   TurnItem turn2;
-  TEST_EQUAL(CheckUTurnOnRoute(resultTest, 2 /* outgoingSegmentIndex */, NumMwmIds(), turn2), 1, ());
+  TEST_EQUAL(CheckUTurnOnRoute(resultTest, 2 /* outgoingSegmentIndex */, NumMwmIds(),
+                               vehicleSettings, turn2),
+             1, ());
   TEST_EQUAL(turn2.m_turn, CarDirection::UTurnLeft, ());
 
   // Empty path test.
   TurnItem turn3;
-  TEST_EQUAL(CheckUTurnOnRoute(resultTest, 3 /* outgoingSegmentIndex */, NumMwmIds(), turn3), 0, ());
+  TEST_EQUAL(CheckUTurnOnRoute(resultTest, 3 /* outgoingSegmentIndex */, NumMwmIds(),
+                               vehicleSettings, turn3),
+             0, ());
 }
 
 UNIT_TEST(GetNextRoutePointIndex)

--- a/routing/turns_generator.cpp
+++ b/routing/turns_generator.cpp
@@ -23,17 +23,6 @@ using namespace std;
 
 namespace
 {
-// @TODO(bykoianko) For the time being |kMaxOutgoingPointsCount| and |kMinOutgoingDistMeters|
-// have value for car navigation. On the other hand it's used for bicycle navigation.
-// But for bicycle navigation the value should be smaller. They should be moved to
-// RoutingSettings structure.
-size_t constexpr kMaxOutgoingPointsCount = 9;
-double constexpr kMinOutgoingDistMeters = 120.0;
-size_t constexpr kMaxIngoingPointsCount = 2;
-double constexpr kMinIngoingDistMeters = 100.0;
-size_t constexpr kNotSoCloseMaxPointsCount = 3;
-double constexpr kNotSoCloseMaxDistMeters = 30.0;
-
 /// \brief Contains information about highway classes of the route goes through a turn
 /// and about highway classes of possible ways from the turn.
 struct TurnHighwayClasses
@@ -581,6 +570,7 @@ bool GetNextRoutePointIndex(IRoutingResult const & result, RoutePointIndex const
 }
 
 RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds const & numMwmIds,
+                                    VehicleType const & vehicleType,
                                     base::Cancellable const & cancellable,
                                     vector<geometry::PointWithAltitude> & junctions,
                                     Route::TTurns & turnsDir, Route::TStreets & streets,
@@ -594,6 +584,9 @@ RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds con
   size_t skipTurnSegments = 0;
   auto const & loadedSegments = result.GetSegments();
   segments.reserve(loadedSegments.size());
+
+  RoutingSettings const vehicleSettings = GetRoutingSettings(vehicleType);
+
   for (auto loadedSegmentIt = loadedSegments.cbegin(); loadedSegmentIt != loadedSegments.cend();
        ++loadedSegmentIt)
   {
@@ -613,10 +606,11 @@ RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds con
       CHECK_GREATER(outgoingSegmentDist, 0, ());
       auto const outgoingSegmentIndex = static_cast<size_t>(outgoingSegmentDist);
 
-      skipTurnSegments = CheckUTurnOnRoute(result, outgoingSegmentIndex, numMwmIds, turnItem);
+      skipTurnSegments =
+          CheckUTurnOnRoute(result, outgoingSegmentIndex, numMwmIds, vehicleSettings, turnItem);
 
       if (turnItem.m_turn == CarDirection::None)
-        GetTurnDirection(result, outgoingSegmentIndex, numMwmIds, turnItem);
+        GetTurnDirection(result, outgoingSegmentIndex, numMwmIds, vehicleSettings, turnItem);
 
       // Lane information.
       if (turnItem.m_turn != CarDirection::None)
@@ -672,12 +666,10 @@ RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds con
   return RouterResultCode::NoError;
 }
 
-RouterResultCode MakeTurnAnnotationPedestrian(IRoutingResult const & result,
-                                              NumMwmIds const & numMwmIds,
-                                              base::Cancellable const & cancellable,
-                                              vector<geometry::PointWithAltitude> & junctions,
-                                              Route::TTurns & turnsDir, Route::TStreets & streets,
-                                              vector<Segment> & segments)
+RouterResultCode MakeTurnAnnotationPedestrian(
+    IRoutingResult const & result, NumMwmIds const & numMwmIds, VehicleType const & vehicleType,
+    base::Cancellable const & cancellable, vector<geometry::PointWithAltitude> & junctions,
+    Route::TTurns & turnsDir, Route::TStreets & streets, vector<Segment> & segments)
 {
   LOG(LDEBUG, ("Shortest path length:", result.GetPathLength()));
 
@@ -687,6 +679,8 @@ RouterResultCode MakeTurnAnnotationPedestrian(IRoutingResult const & result,
   size_t skipTurnSegments = 0;
   auto const & loadedSegments = result.GetSegments();
   segments.reserve(loadedSegments.size());
+
+  RoutingSettings const vehicleSettings = GetRoutingSettings(vehicleType);
 
   for (auto loadedSegmentIt = loadedSegments.cbegin(); loadedSegmentIt != loadedSegments.cend();
        ++loadedSegmentIt)
@@ -708,7 +702,8 @@ RouterResultCode MakeTurnAnnotationPedestrian(IRoutingResult const & result,
 
       TurnItem turnItem;
       turnItem.m_index = static_cast<uint32_t>(junctions.size() - 1);
-      GetTurnDirectionPedestrian(result, outgoingSegmentIndex, numMwmIds, turnItem);
+      GetTurnDirectionPedestrian(result, outgoingSegmentIndex, numMwmIds, vehicleSettings,
+                                 turnItem);
 
       if (turnItem.m_pedestrianTurn != PedestrianDirection::None)
         turnsDir.push_back(move(turnItem));
@@ -994,7 +989,8 @@ bool HasMultiTurns(NumMwmIds const & numMwmIds, TurnCandidates const & turnCandi
 }
 
 void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex,
-                      NumMwmIds const & numMwmIds, TurnItem & turn)
+                      NumMwmIds const & numMwmIds, RoutingSettings const & vehicleSettings,
+                      TurnItem & turn)
 {
   auto const & segments = result.GetSegments();
   CHECK_LESS(outgoingSegmentIndex, segments.size(), ());
@@ -1011,12 +1007,12 @@ void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex
               kFeaturesNearTurnMeters, ());
 
   m2::PointD const junctionPoint = turnInfo.m_ingoing.m_path.back().GetPoint();
-  m2::PointD const ingoingPoint =
-      GetPointForTurn(result, outgoingSegmentIndex, numMwmIds, kMaxIngoingPointsCount,
-                      kMinIngoingDistMeters, false /* forward */);
-  m2::PointD const outgoingPoint =
-      GetPointForTurn(result, outgoingSegmentIndex, numMwmIds, kMaxOutgoingPointsCount,
-                      kMinOutgoingDistMeters, true /* forward */);
+  m2::PointD const ingoingPoint = GetPointForTurn(
+      result, outgoingSegmentIndex, numMwmIds, vehicleSettings.m_maxIngoingPointsCount,
+      vehicleSettings.m_minIngoingDistMeters, false /* forward */);
+  m2::PointD const outgoingPoint = GetPointForTurn(
+      result, outgoingSegmentIndex, numMwmIds, vehicleSettings.m_maxOutgoingPointsCount,
+      vehicleSettings.m_minOutgoingDistMeters, true /* forward */);
 
   double const turnAngle = base::RadToDeg(PiMinusTwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint));
   CarDirection const intermediateDirection = IntermediateDirection(turnAngle);
@@ -1100,9 +1096,9 @@ void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex
 
   if (IsGoStraightOrSlightTurn(turn.m_turn))
   {
-    auto const notSoCloseToTheTurnPoint =
-        GetPointForTurn(result, outgoingSegmentIndex, numMwmIds, kNotSoCloseMaxPointsCount,
-                        kNotSoCloseMaxDistMeters, false /* forward */);
+    auto const notSoCloseToTheTurnPoint = GetPointForTurn(
+        result, outgoingSegmentIndex, numMwmIds, vehicleSettings.m_notSoCloseMaxPointsCount,
+        vehicleSettings.m_notSoCloseMaxDistMeters, false /* forward */);
 
     // Removing a slight turn if there's only one way to leave the turn and there's no ingoing edges.
     if (!KeepTurnByIngoingEdges(junctionPoint, notSoCloseToTheTurnPoint, outgoingPoint, hasMultiTurns,
@@ -1151,7 +1147,8 @@ void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex
 }
 
 void GetTurnDirectionPedestrian(IRoutingResult const & result, size_t outgoingSegmentIndex,
-                                NumMwmIds const & numMwmIds, TurnItem & turn)
+                                NumMwmIds const & numMwmIds,
+                                RoutingSettings const & vehicleSettings, TurnItem & turn)
 {
   auto const & segments = result.GetSegments();
   CHECK_LESS(outgoingSegmentIndex, segments.size(), ());
@@ -1168,12 +1165,12 @@ void GetTurnDirectionPedestrian(IRoutingResult const & result, size_t outgoingSe
               kFeaturesNearTurnMeters, ());
 
   m2::PointD const junctionPoint = turnInfo.m_ingoing.m_path.back().GetPoint();
-  m2::PointD const ingoingPoint =
-      GetPointForTurn(result, outgoingSegmentIndex, numMwmIds, kMaxIngoingPointsCount,
-                      kMinIngoingDistMeters, false /* forward */);
-  m2::PointD const outgoingPoint =
-      GetPointForTurn(result, outgoingSegmentIndex, numMwmIds, kMaxOutgoingPointsCount,
-                      kMinOutgoingDistMeters, true /* forward */);
+  m2::PointD const ingoingPoint = GetPointForTurn(
+      result, outgoingSegmentIndex, numMwmIds, vehicleSettings.m_maxIngoingPointsCount,
+      vehicleSettings.m_minIngoingDistMeters, false /* forward */);
+  m2::PointD const outgoingPoint = GetPointForTurn(
+      result, outgoingSegmentIndex, numMwmIds, vehicleSettings.m_maxOutgoingPointsCount,
+      vehicleSettings.m_minOutgoingDistMeters, true /* forward */);
 
   double const turnAngle =
       base::RadToDeg(PiMinusTwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint));
@@ -1213,7 +1210,8 @@ void GetTurnDirectionPedestrian(IRoutingResult const & result, size_t outgoingSe
 }
 
 size_t CheckUTurnOnRoute(IRoutingResult const & result, size_t outgoingSegmentIndex,
-                         NumMwmIds const & numMwmIds, TurnItem & turn)
+                         NumMwmIds const & numMwmIds, RoutingSettings const & vehicleSettings,
+                         TurnItem & turn)
 {
   size_t constexpr kUTurnLookAhead = 3;
   double constexpr kUTurnHeadingSensitivity = math::pi / 10.0;
@@ -1279,12 +1277,12 @@ size_t CheckUTurnOnRoute(IRoutingResult const & result, size_t outgoingSegmentIn
       // Determine turn direction.
       m2::PointD const junctionPoint = masterSegment.m_path.back().GetPoint();
 
-      m2::PointD const ingoingPoint =
-          GetPointForTurn(result, outgoingSegmentIndex, numMwmIds, kMaxIngoingPointsCount,
-                          kMinIngoingDistMeters, false /* forward */);
-      m2::PointD const outgoingPoint =
-          GetPointForTurn(result, outgoingSegmentIndex, numMwmIds, kMaxOutgoingPointsCount,
-                          kMinOutgoingDistMeters, true /* forward */);
+      m2::PointD const ingoingPoint = GetPointForTurn(
+          result, outgoingSegmentIndex, numMwmIds, vehicleSettings.m_maxIngoingPointsCount,
+          vehicleSettings.m_minIngoingDistMeters, false /* forward */);
+      m2::PointD const outgoingPoint = GetPointForTurn(
+          result, outgoingSegmentIndex, numMwmIds, vehicleSettings.m_maxOutgoingPointsCount,
+          vehicleSettings.m_minOutgoingDistMeters, true /* forward */);
 
       if (PiMinusTwoVectorsAngle(junctionPoint, ingoingPoint, outgoingPoint) < 0)
         turn.m_turn = CarDirection::UTurnLeft;

--- a/routing/turns_generator.hpp
+++ b/routing/turns_generator.hpp
@@ -1,17 +1,18 @@
 #pragma once
 
 #include "routing/loaded_path_segment.hpp"
-#include "routing/routing_callbacks.hpp"
-#include "routing/routing_result_graph.hpp"
 #include "routing/route.hpp"
 #include "routing/router.hpp"
-#include "routing/turns.hpp"
-#include "routing/turn_candidate.hpp"
+#include "routing/routing_callbacks.hpp"
+#include "routing/routing_result_graph.hpp"
 #include "routing/segment.hpp"
-
-#include "routing_common/num_mwm_id.hpp"
+#include "routing/turn_candidate.hpp"
+#include "routing/turns.hpp"
+#include "routing/vehicle_mask.hpp"
 
 #include "traffic/traffic_info.hpp"
+
+#include "routing_common/num_mwm_id.hpp"
 
 #include "geometry/point_with_altitude.hpp"
 
@@ -96,19 +97,19 @@ bool GetNextRoutePointIndex(IRoutingResult const & result, RoutePointIndex const
  * \return routing operation result code.
  */
 RouterResultCode MakeTurnAnnotation(IRoutingResult const & result, NumMwmIds const & numMwmIds,
+                                    VehicleType const & vehicleType,
                                     base::Cancellable const & cancellable,
                                     std::vector<geometry::PointWithAltitude> & points,
                                     Route::TTurns & turnsDir, Route::TStreets & streets,
                                     std::vector<Segment> & segments);
 
-RouterResultCode MakeTurnAnnotationPedestrian(IRoutingResult const & result,
-                                              NumMwmIds const & numMwmIds,
-                                              base::Cancellable const & cancellable,
-                                              std::vector<geometry::PointWithAltitude> & points,
-                                              Route::TTurns & turnsDir, Route::TStreets & streets,
-                                              std::vector<Segment> & segments);
+RouterResultCode MakeTurnAnnotationPedestrian(
+    IRoutingResult const & result, NumMwmIds const & numMwmIds, VehicleType const & vehicleType,
+    base::Cancellable const & cancellable, std::vector<geometry::PointWithAltitude> & points,
+    Route::TTurns & turnsDir, Route::TStreets & streets, std::vector<Segment> & segments);
 
-// Returns the distance in meractor units for the path of points for the range [startPointIndex, endPointIndex].
+// Returns the distance in mercator units for the path of points for the range [startPointIndex,
+// endPointIndex].
 double CalculateMercatorDistanceAlongPath(uint32_t startPointIndex, uint32_t endPointIndex,
                                           std::vector<m2::PointD> const & points);
 
@@ -175,9 +176,11 @@ CarDirection GetRoundaboutDirection(bool isIngoingEdgeRoundabout, bool isOutgoin
  * \param turn is used for keeping the result of turn calculation.
  */
 void GetTurnDirection(IRoutingResult const & result, size_t outgoingSegmentIndex,
-                      NumMwmIds const & numMwmIds, TurnItem & turn);
+                      NumMwmIds const & numMwmIds, RoutingSettings const & vehicleSettings,
+                      TurnItem & turn);
 void GetTurnDirectionPedestrian(IRoutingResult const & result, size_t outgoingSegmentIndex,
-                                NumMwmIds const & numMwmIds, TurnItem & turn);
+                                NumMwmIds const & numMwmIds,
+                                RoutingSettings const & vehicleSettings, TurnItem & turn);
 
 /*!
  * \brief Finds an U-turn that starts from master segment and returns how many segments it lasts.
@@ -186,7 +189,8 @@ void GetTurnDirectionPedestrian(IRoutingResult const & result, size_t outgoingSe
  * \warning |currentSegment| must be greater than 0.
  */
 size_t CheckUTurnOnRoute(IRoutingResult const & result, size_t outgoingSegmentIndex,
-                         NumMwmIds const & numMwmIds, TurnItem & turn);
+                         NumMwmIds const & numMwmIds, RoutingSettings const & vehicleSettings,
+                         TurnItem & turn);
 
 std::string DebugPrint(RoutePointIndex const & index);
 }  // namespace routing


### PR DESCRIPTION
Для дальнейшей кастомизации маневров потребовалось реализовать эту todo из TurnsGenerator:
```
// @TODO(bykoianko) For the time being |kMaxOutgoingPointsCount| and |kMinOutgoingDistMeters|		
 // have value for car navigation. On the other hand it's used for bicycle navigation.		
 // But for bicycle navigation the value should be smaller. They should be moved to		
 // RoutingSettings structure.
```

Теперь для пешеходов и велосипедов можно задавать свои значения.