### PR TITLE
[routing] Handle corner-cases in pedestrian & bicycle turns.

### DIFF
--- a/routing/routing_integration_tests/bicycle_turn_test.cpp
+++ b/routing/routing_integration_tests/bicycle_turn_test.cpp
@@ -19,16 +19,12 @@ UNIT_TEST(RussiaMoscowSevTushinoParkBicycleWayTurnTest)
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
 
-  integration::TestTurnCount(route, 5 /* expectedTurnCount */);
+  integration::TestTurnCount(route, 3 /* expectedTurnCount */);
   integration::GetNthTurn(route, 0).TestValid().TestOneOfDirections(
       {CarDirection::TurnSlightRight});
   integration::GetNthTurn(route, 1).TestValid().TestOneOfDirections(
-      {CarDirection::GoStraight, CarDirection::TurnSlightLeft});
-  integration::GetNthTurn(route, 2).TestValid().TestOneOfDirections(
-      {CarDirection::GoStraight, CarDirection::TurnSlightRight});
-  integration::GetNthTurn(route, 3).TestValid().TestDirection(CarDirection::TurnLeft);
-  integration::GetNthTurn(route, 4).TestValid().TestOneOfDirections(
-      {CarDirection::TurnSlightRight, CarDirection::TurnRight});
+      {CarDirection::TurnLeft});
+
   integration::TestRouteLength(route, 753.0);
 }
 
@@ -61,8 +57,8 @@ UNIT_TEST(RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest)
   TEST_EQUAL(result, RouterResultCode::NoError, ());
 
   integration::TestTurnCount(route, 3 /* expectedTurnCount */);
-  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnSlightRight);
-  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnRight);
+  integration::GetNthTurn(route, 0).TestValid().TestDirection(CarDirection::TurnRight);
+  integration::GetNthTurn(route, 1).TestValid().TestDirection(CarDirection::TurnSlightRight);
   integration::GetNthTurn(route, 2).TestValid().TestDirection(CarDirection::TurnLeft);
 }
 

--- a/routing/routing_settings.cpp
+++ b/routing/routing_settings.cpp
@@ -72,9 +72,9 @@ RoutingSettings GetRoutingSettings(VehicleType vehicleType)
             -1 /* m_minSpeedForRouteRebuildMpS */,
             15.0 /* m_finishToleranceM */,
             9 /* m_maxOutgoingPointsCount */,
-            90.0 /* m_minOutgoingDistMeters */,
+            10.0 /* m_minOutgoingDistMeters */,
             2 /* m_maxIngoingPointsCount */,
-            70.0 /* m_minIngoingDistMeters */,
+            10.0 /* m_minIngoingDistMeters */,
             3 /* m_notSoCloseMaxPointsCount */,
             25.0 /* m_notSoCloseMaxDistMeters */};
   case VehicleType::Car:


### PR DESCRIPTION
### Описание некорректных маневров
В некоторых случаях мы генерим некорректные маневры. Примеры:
Вело-маршрут 55.915690, 37.589723; 55.915838, 37.575417. Два маневра почти в одной точке:
TurnLeft : 2
TurnSlightRight : 3

И оба некорректные. В этой точке маневр вообще не нужен, потому что фейковая дуга составляет меньше 20 метров.
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/54934129/96702905-e69ef300-139a-11eb-97bd-674713ac1026.png">
Фикс:
<img width="974" alt="image" src="https://user-images.githubusercontent.com/54934129/96711045-9aa57b80-13a5-11eb-85d0-99d038e0b976.png">
Вело-маршрут 55.917881, 37.586037; 55.916844, 37.578845. 
TurnLeft : 2
TurnSlightRight : 3  
Нужен TurnRight.
<img width="966" alt="image" src="https://user-images.githubusercontent.com/54934129/96703814-f965f780-139b-11eb-945a-3089b26da581.png">
Фикс:
<img width="937" alt="image" src="https://user-images.githubusercontent.com/54934129/96711140-c0cb1b80-13a5-11eb-9039-df72670c7eaa.png">


Вело-маршрут 55.869733, 37.458253; 55.870205, 37.460111.
Лишний маневр turnSlightRight:
<img width="789" alt="image" src="https://user-images.githubusercontent.com/54934129/96704181-71342200-139c-11eb-82ca-9e557b504da7.png">
Фикс:
<img width="814" alt="image" src="https://user-images.githubusercontent.com/54934129/96739661-b53d1c00-13c8-11eb-88d4-e3ac745d535a.png">

### Причины и фиксы
1. При расчете угла маневра мы используем три точки: саму точку маневра, точку "слегка позади" и точку "слегка впереди" на маршруте. Возможна ситуация, когда две из этих точек совпадают (первая и вторая или вторая и третья), и угол рассчитывается неверно (-10 градусов вместо +150, +20 вместо -35 и тд). Это происходит, если попадаются точки на фейковой петле. Добавлена обработка этого кейса.
2. Константы, обозначающие "что такое точка немного впереди/позади" для великов сильно завышены. Для петляющих дорожек в парке, коротких дорог во дворах и тд они очень часто дают слишком отдаленные точки в методе GetPointForTurn(), а соответственно и угол, принципиально отличающийся от действительного. Эти константы уменьшены.

### Обновленные интеграционные тесты
2 теста, оба на велики.

**RussiaMoscowSevTushinoParkBicycleWayTurnTest**
Было 5 маневров, стало 3. Убраны TurnSlightLeft и TurnSlightRight, где нужно ехать ровно прямо.
Было:
<img width="1625" alt="Screenshot 2020-10-21 at 16 15 40" src="https://user-images.githubusercontent.com/54934129/96733333-fa118480-13c1-11eb-9b5b-37c63c1911d2.png">
Стало:
<img width="1619" alt="Screenshot 2020-10-21 at 15 58 52" src="https://user-images.githubusercontent.com/54934129/96733394-0f86ae80-13c2-11eb-8deb-61fc59b00b9b.png">

**RussiaMoscowSalameiNerisPossibleTurnCorrectionBicycleWayTurnTest**
Первый TurnSlightRight заменен на TurnRight. Второй TurnRight заменен на TurnSlightRight.
Было:
<img width="979" alt="Screenshot 2020-10-21 at 16 14 25" src="https://user-images.githubusercontent.com/54934129/96735710-83c25180-13c4-11eb-935f-3910c3ee980b.png">
Стало:
<img width="893" alt="Screenshot 2020-10-21 at 16 12 30" src="https://user-images.githubusercontent.com/54934129/96736840-b02a9d80-13c5-11eb-9a1a-14eb8cf4816c.png">
