### PR TITLE
[android] Fixed whats new screen and strings for lp.

### DIFF
--- a/android/res/values/arrays.xml
+++ b/android/res/values/arrays.xml
@@ -11,7 +11,7 @@
   </string-array>
 
   <string-array name="news_messages_1">
-    <item>@string/whatsnew_lp_integration_message</item>
+    <item>@string/whatsnew_lp_message</item>
   </string-array>
 
   <string-array name="news_messages_2">

--- a/android/src/com/mapswithme/maps/bookmarks/BookmarkCollectionAdapter.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarkCollectionAdapter.java
@@ -56,8 +56,7 @@ public class BookmarkCollectionAdapter extends RecyclerView.Adapter<RecyclerView
   public String getTitle(int sectionIndex, @NonNull Resources rs)
   {
     if (sectionIndex == mCollectionSectionIndex)
-      // TODO (@velichkomarija): Replace categories for collections.
-      return rs.getString(R.string.categories);
+      return rs.getString(R.string.collections_title);
     return rs.getString(R.string.categories);
   }
 

--- a/android/src/com/mapswithme/maps/bookmarks/BookmarkHeaderView.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarkHeaderView.java
@@ -100,8 +100,7 @@ public class BookmarkHeaderView extends LinearLayout
         else
           UiUtils.hide(mImageViewLogo);
 
-        //TODO: (@velichkomarija) : Replace with "Content by ".
-        CharSequence authorName = BookmarkCategory.Author.getRepresentation(context, author);
+        CharSequence authorName = BookmarkCategory.Author.getContentByString(context, author);
         mAuthorTextView.setText(authorName);
       }
     }

--- a/android/src/com/mapswithme/maps/bookmarks/data/BookmarkCategory.java
+++ b/android/src/com/mapswithme/maps/bookmarks/data/BookmarkCategory.java
@@ -273,6 +273,12 @@ public class BookmarkCategory implements Parcelable
       return String.format(res.getString(R.string.author_name_by_prefix), author.getName());
     }
 
+    public static String getContentByString(@NonNull Context context, @NonNull Author author)
+    {
+      Resources res = context.getResources();
+      return res.getString(R.string.content_by_component).concat(" ").concat(author.getName());
+    }
+
     @Override
     public void writeToParcel(Parcel dest, int flags)
     {


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-14856 

Исправлено наименование строки для what's new.
Вставлены переводы для guide's page.
При сборке дебажной версии не могу запуститься, так как все крашится из-за "слишком глубокого сбора логов". Может стоит где-то их подчистить?

@Polas, почему "Content by" строка с двоеточием? Это новое уточнение, в конфлюенсе версия без двоеточия.

