### PR TITLE
Concurrent feature parsing.

### DIFF
--- a/indexer/data_source.hpp
+++ b/indexer/data_source.hpp
@@ -89,6 +89,11 @@ public:
 
 /// Guard for loading features from particular MWM by demand.
 /// @note This guard is suitable when mwm is loaded.
+/// @note If you need to work with |FeatureType| from different threads you need to use
+/// a unique |FeaturesLoaderGuard| instance for every threads. Construction of
+/// |FeaturesLoaderGuard| should be serialized. Then instances of |FeaturesLoaderGuard|
+/// may be used concurrently. The example of concurrent use of |FeaturesLoaderGuard|
+/// please see |ConcurrentFeatureParsingTest|.
 class FeaturesLoaderGuard
 {
 public:

--- a/indexer/data_source.hpp
+++ b/indexer/data_source.hpp
@@ -89,11 +89,10 @@ public:
 
 /// Guard for loading features from particular MWM by demand.
 /// @note This guard is suitable when mwm is loaded.
-/// @note If you need to work with |FeatureType| from different threads you need to use
-/// a unique |FeaturesLoaderGuard| instance for every threads. Construction of
-/// |FeaturesLoaderGuard| should be serialized. Then instances of |FeaturesLoaderGuard|
-/// may be used concurrently. The example of concurrent use of |FeaturesLoaderGuard|
-/// please see |ConcurrentFeatureParsingTest|.
+/// @note If you need to work with FeatureType from different threads you need to use
+/// a unique FeaturesLoaderGuard instance for every thread. But construction of instances of
+/// FeaturesLoaderGuard should be serialized. For an example of concurrent extracting feature
+/// details please see ConcurrentFeatureParsingTest.
 class FeaturesLoaderGuard
 {
 public:

--- a/routing/routing_integration_tests/CMakeLists.txt
+++ b/routing/routing_integration_tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(
   archival_reporter_tests.cpp
   bicycle_route_test.cpp
   bicycle_turn_test.cpp
+  concurrent_feature_parsing_test.cpp
   cross_country_routing_tests.cpp
   get_altitude_test.cpp
   guides_tests.cpp

--- a/routing/routing_integration_tests/concurrent_feature_parsing_test.cpp
+++ b/routing/routing_integration_tests/concurrent_feature_parsing_test.cpp
@@ -71,8 +71,8 @@ void TestConcurrentAccessToFeatures(string const & mwm)
   futures.reserve(threadNumber);
   vector<vector<m2::PointD>> pointsByThreads;
   pointsByThreads.resize(threadNumber);
-  for (size_t i = 0; i < threadNumber - 1; ++i)
-    futures.push_back(std::async(std::launch::async, parseGeometries, ref(pointsByThreads[i])));
+  for (size_t i = 0; i + 1 < threadNumber; ++i)
+    futures.push_back(async(launch::async, parseGeometries, ref(pointsByThreads[i])));
   parseGeometries(pointsByThreads[threadNumber - 1]);
 
   for (auto const & fut : futures)

--- a/routing/routing_integration_tests/concurrent_feature_parsing_test.cpp
+++ b/routing/routing_integration_tests/concurrent_feature_parsing_test.cpp
@@ -1,0 +1,87 @@
+#include "testing/testing.hpp"
+
+#include "routing/routing_integration_tests/routing_test_tools.hpp"
+
+#include "indexer/classificator_loader.hpp"
+#include "indexer/data_source.hpp"
+
+#include "platform/country_file.hpp"
+#include "platform/local_country_file.hpp"
+
+#include "base/logging.hpp"
+
+#include <algorithm>
+#include <future>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+using namespace platform;
+using namespace std;
+
+void TestConcurrentAccessToFeatures(string const & mwm)
+{
+  FrozenDataSource dataSource;
+
+  auto const & countryFile = CountryFile(mwm);
+  auto const & local = integration::GetLocalCountryFileByCountryId(countryFile);
+  TEST_NOT_EQUAL(local, LocalCountryFile(), ());
+  TEST(local.HasFiles(), (local));
+
+  auto const mwmIdAndRegResult = dataSource.RegisterMap(local);
+  TEST_EQUAL(mwmIdAndRegResult.second, MwmSet::RegResult::Success, (local));
+  TEST(mwmIdAndRegResult.first.IsAlive(), (local));
+
+  auto const handle = dataSource.GetMwmHandleByCountryFile(countryFile);
+  TEST(handle.IsAlive(), (local));
+
+  auto const featureNumber = handle.GetValue()->m_table->size();
+  // Note. If hardware_concurrency() returns 0 it means that number of core is not defined.
+  // If hardware_concurrency() returns 1 it means that only one core is available.
+  // In the both cases 2 threads should be used for this test.
+  auto const threadNumber = max(thread::hardware_concurrency(), static_cast<unsigned int>(2));
+  LOG(LINFO, ("Parsing geometry of", featureNumber, "features in", threadNumber,
+              "threads simultaneously.", local));
+
+  mutex guardCtorMtx;
+  auto parseGeometries = [&guardCtorMtx, &featureNumber,  &dataSource, &handle, &local](){
+    unique_lock<mutex> guardCtor(guardCtorMtx);
+    FeaturesLoaderGuard guard(dataSource, handle.GetId());
+    guardCtor.unlock();
+
+    for (uint32_t i = 0; i < featureNumber; ++i)
+    {
+      auto feature = guard.GetFeatureByIndex(i);
+      TEST(feature, ("Feature id:", i, "is not found in", local));
+
+      feature->ParseGeometry(FeatureType::BEST_GEOMETRY);
+    }
+  };
+
+  vector<future<void>> futures;
+  futures.reserve(threadNumber);
+  for (size_t i = 0; i < threadNumber - 1; ++i)
+    futures.push_back(std::async(std::launch::async, parseGeometries));
+  parseGeometries();
+
+  for (auto const & fut : futures)
+    fut.wait();
+
+  LOG(LINFO, ("Parsing is done."));
+}
+
+// This test on availability of parsing FeatureType in several threads.
+UNIT_TEST(ConcurrentFeatureParsingTest)
+{
+  classificator::Load();
+
+  vector<string> const mwms = {"Russia_Moscow", "Nepal_Kathmandu",
+                               "Netherlands_North Holland_Amsterdam"};
+
+  for (auto const & mwm : mwms)
+    TestConcurrentAccessToFeatures(mwm);
+}
+}  // namespace

--- a/routing/routing_integration_tests/concurrent_feature_parsing_test.cpp
+++ b/routing/routing_integration_tests/concurrent_feature_parsing_test.cpp
@@ -62,7 +62,7 @@ void TestConcurrentAccessToFeatures(string const & mwm)
       TEST(feature, ("Feature id:", i, "is not found in", local));
 
       feature->ParseGeometry(FeatureType::BEST_GEOMETRY);
-      for (size_t i = 0; i < feature->GetTypesCount(); ++i)
+      for (size_t i = 0; i < feature->GetPointsCount(); ++i)
         points.push_back(feature->GetPoint(i));
     }
   };

--- a/routing/routing_integration_tests/get_altitude_test.cpp
+++ b/routing/routing_integration_tests/get_altitude_test.cpp
@@ -30,8 +30,6 @@ using namespace feature;
 using namespace platform;
 using namespace std;
 
-
-
 void TestAltitudeOfAllMwmFeatures(string const & countryId,
                                   geometry::Altitude const altitudeLowerBoundMeters,
                                   geometry::Altitude const altitudeUpperBoundMeters)

--- a/routing/routing_integration_tests/get_altitude_test.cpp
+++ b/routing/routing_integration_tests/get_altitude_test.cpp
@@ -30,18 +30,7 @@ using namespace feature;
 using namespace platform;
 using namespace std;
 
-LocalCountryFile GetLocalCountryFileByCountryId(CountryFile const & country)
-{
-  vector<LocalCountryFile> localFiles;
-  integration::GetAllLocalFiles(localFiles);
 
-  for (auto const & lf : localFiles)
-  {
-    if (lf.GetCountryFile() == country)
-      return lf;
-  }
-  return {};
-}
 
 void TestAltitudeOfAllMwmFeatures(string const & countryId,
                                   geometry::Altitude const altitudeLowerBoundMeters,
@@ -49,7 +38,7 @@ void TestAltitudeOfAllMwmFeatures(string const & countryId,
 {
   FrozenDataSource dataSource;
 
-  LocalCountryFile const country = GetLocalCountryFileByCountryId(CountryFile(countryId));
+  LocalCountryFile const country = integration::GetLocalCountryFileByCountryId(CountryFile(countryId));
   TEST_NOT_EQUAL(country, LocalCountryFile(), ());
   TEST(country.HasFiles(), (country));
 

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -397,7 +397,7 @@ void CheckSubwayExistence(Route const & route)
 LocalCountryFile GetLocalCountryFileByCountryId(platform::CountryFile const & country)
 {
   vector<LocalCountryFile> localFiles;
-  integration::GetAllLocalFiles(localFiles);
+  GetAllLocalFiles(localFiles);
 
   for (auto const & lf : localFiles)
   {
@@ -406,4 +406,4 @@ LocalCountryFile GetLocalCountryFileByCountryId(platform::CountryFile const & co
   }
   return {};
 }
-}  // namespace
+}  // namespace integration

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -393,4 +393,17 @@ void CheckSubwayExistence(Route const & route)
   bool wasSubway = IsSubwayExists(route);
   TEST(wasSubway, ("Can not find subway subpath into route."));
 }
+
+LocalCountryFile GetLocalCountryFileByCountryId(platform::CountryFile const & country)
+{
+  vector<LocalCountryFile> localFiles;
+  integration::GetAllLocalFiles(localFiles);
+
+  for (auto const & lf : localFiles)
+  {
+    if (lf.GetCountryFile() == country)
+      return lf;
+  }
+  return {};
+}
 }  // namespace

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -7,6 +7,7 @@
 
 #include "map/features_fetcher.hpp"
 
+#include "platform/country_file.hpp"
 #include "platform/local_country_file.hpp"
 
 #include <cstdint>
@@ -176,4 +177,6 @@ TestTurn GetNthTurn(Route const & route, uint32_t turnNumber);
 void TestCurrentStreetName(routing::Route const & route, std::string const & expectedStreetName);
 
 void TestNextStreetName(routing::Route const & route, std::string const & expectedStreetName);
+
+LocalCountryFile GetLocalCountryFileByCountryId(platform::CountryFile const & country);
 }  // namespace integration


### PR DESCRIPTION
**Цели данного PR**
(1) показать, как я собираюсь парсить фичи в несколько потоков на обособленном примере;
(2) протестировать работоспособность способа.

**Обоснование, почему можно парсить фичи в несколько потоков с несколькими `FeaturesLoaderGuard`**
Под каждый `FeaturesLoaderGuard` создается свой собственный `MwmHandle` в `MwmSet::GetMwmHandleByIdImpl()`. А стало быть свой собственный `MwmValue` в `DataSource::CreateValue()`. А для него создается свой собственный ридер в `platform::GetCountryReader()`. Т.е. для каждого `FeaturesLoaderGuard` создается свой собственный кэш (4MB) для чтения геометрии с диска.

При создании `FeaturesLoaderGuard` вызывается `DataSource::GetMwmHandleById()`. Он, в свою очередь, через цепочку вызовов вызывает `MwmSet::LockValueImpl()`, который в обращается без синхронизации к `MwmSet::m_cache`. Поэтому сами экземпляры `FeaturesLoaderGuard` должны создаваться не одновременно. А затем их можно параллельно использовать. Поэтому для создания `FeaturesLoaderGuard` используется mutex.

**Расположение данного теста**
Весьма спорным представляется располагать данный тест в routing_integration_tests. Однако учитывая, что:
- в routing_integration_tests есть доступ к реальным mwm, а для теста нужно большие mwm;
- этот тест делается сейчас для routing-га;
- ситуация аналогична тестам на секцию altitude;
я расположил его здесь.

@mesozoic-drones @tatiana-yan @mpimenov PTAL