### PR TITLE
[guides on map] zoom-out from incorrect place is fixed.

### DIFF
--- a/map/guides_manager.cpp
+++ b/map/guides_manager.cpp
@@ -74,7 +74,7 @@ void GuidesManager::SetStateListener(GuidesStateChangedFn const & onStateChanged
 
 void GuidesManager::UpdateViewport(ScreenBase const & screen)
 {
-  m_lastShownViewport = m_screen.GlobalRect();
+  m_lastShownViewport = screen.GlobalRect();
   auto const zoom = df::GetDrawTileScale(screen);
 
   if (m_state == GuidesState::Disabled || m_state == GuidesState::FatalNetworkError)


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-15122

Была опечатка и из-за нее в момент отзумливания `m_lastShownViewport` мог быть инициализирован значениями вьюпорта по-умолчанию (это прямоугольник c 640 на 480), центр которого оказывался вне координат меркатора.