### PR TITLE
[routing] Routing performance optimization. Stop checking twin features geometry on the same mwm versions.

### DIFF
--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -135,14 +135,24 @@ public:
 
       CHECK_NOT_EQUAL(twinSeg->GetMwmId(), s.GetMwmId(), ());
 
-      // Checks twins for equality.
+      // Checks twins for equality if they are from different mwm versions.
       // There are same in common, but in case of different version of mwms
       // their's geometry can differ from each other. Because of this we can not
       // build the route, because we fail in astar_algorithm.hpp CHECK(invariant) sometimes.
-      if (SegmentsAreEqualByGeometry(s, *twinSeg))
+      auto const & sMwmId = m_dataSource.GetMwmIdByCountryFile(m_numMwmIds->GetFile(s.GetMwmId()));
+      CHECK(sMwmId.IsAlive(), (s));
+      auto const & twinSegMwmId =
+          m_dataSource.GetMwmIdByCountryFile(m_numMwmIds->GetFile(twinSeg->GetMwmId()));
+      CHECK(twinSegMwmId.IsAlive(), (*twinSeg));
+      if (sMwmId.GetInfo()->GetVersion() == twinSegMwmId.GetInfo()->GetVersion() ||
+          SegmentsAreEqualByGeometry(s, *twinSeg))
+      {
         twins.push_back(*twinSeg);
+      }
       else
+      {
         LOG(LINFO, ("Bad cross mwm feature, differ in geometry. Current:", s, ", twin:", *twinSeg));
+      }
     }
   }
 
@@ -206,7 +216,6 @@ private:
     };
 
     m_dataSource.ReadFeature(fillGeometry, featureId);
-
     return geometry;
   }
 


### PR DESCRIPTION
Данный PR дает 20-25% ускорения прокладки маршрутов на всех типах роутинга при условии, что mwms в районе прокладки маршрута одной версии (одной даты сборки).

Он достигает этого за счет отдельной обработки основного кейса при переходе волны A* через границу mwm: mwm-ки на переходе одной и той же версии. Если версии на данном переходе разные, то будет работать старый код.

Около 2 лет назад мы сделали PR мы заметили, что если соседние mwm содержат разную геометрию переходных фичь, то в A* может сработать чек, мы предполагали, что геометрия переходных фичь совпадает и вес перехода равен 0. Разная геометрия переходных фичь возможна, если соседние mwm имеют разные версии. Мы сделали PR, который исправлял проблему  https://github.com/mapsme/omim/pull/10006. Он проверял геометрию переходных фичь и если она различалась, то не допускал перехода. Геометрия переходных фичь проверялась всегда. Даже если версии mwm совпадали. Хотя в этом случае это было излишне. Поле данного PR не было проведено ни профилирование ни бенчмарки. А эта проверка геометрии замедлила роутинг на 20-25%. Вернее 20-25% занимало ее извлечение их противоположенной mwm.

Суть данного PR проста. Прежде чем извлекать геометрию, мы проверяем, не совпадают ли версии mwm. И если версии mwm совпадают, мы полагаем, что геометрия фичей так же совпадает.

Надо бы на будущее сделать регулярные benchmarks, чтоб про подобные замедления сразу узнавать.

**Время прокладки. Пара замеров.**
Далее замеры на iPhone SE. По 3 прокладки маршрута, после запуска приложения.
Время прокладки маршрута: подготовка к работе A*, работа A*, постобработка.
Офис-Таруса, пешеходный (55.797141, 37.538170; 54.719608, 37.194492)

На данном PR:
36473 ms
34834 ms
34071 ms

На мастере:
47531 ms
41415 ms
40806 ms

Москва-Питер, авто (55.750447, 37.617495; 59.938734)
На данном PR:
8673 ms
6237 ms
6093 ms

На мастере:
10754 ms
9186 ms
8510 ms

**Результаты сравнительного профайлинга на iPhone SE.**
![image](https://user-images.githubusercontent.com/1768114/96733082-ba4a9d00-13c1-11eb-9bca-a1aeadfcc474.png)

@mesozoic-drones @tatiana-yan PTAL