### PR TITLE
[android] Fixed night theme in ads removal screen.

### DIFF
--- a/android/res/layout-land/fragment_ads_removal_purchase_dialog.xml
+++ b/android/res/layout-land/fragment_ads_removal_purchase_dialog.xml
@@ -4,6 +4,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_height="match_parent"
   android:layout_width="match_parent"
+  android:background="?cardBackground"
   android:fillViewport="true">
   <RelativeLayout
     android:layout_width="wrap_content"
@@ -12,6 +13,7 @@
     android:padding="@dimen/margin_base_plus"
     android:orientation="vertical">
     <TextView
+      style="?fontHeadline5"
       android:id="@+id/title"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
@@ -19,7 +21,6 @@
       android:layout_centerHorizontal="true"
       android:gravity="center"
       android:layout_gravity="center_horizontal"
-      android:textAppearance="@style/MwmTextAppearance.Title"
       android:visibility="invisible"
       tools:visibility="visible"/>
     <include

--- a/android/res/layout/ads_removal_pay_button_container.xml
+++ b/android/res/layout/ads_removal_pay_button_container.xml
@@ -25,7 +25,8 @@
       android:textSize="@dimen/text_size_toolbar"
       android:textAllCaps="true"
       android:ellipsize="end"
-      android:gravity="center"/>
+      android:gravity="center"
+      tools:text="@string/remove_ads"/>
     <TextView
       android:id="@+id/saving"
       android:layout_width="match_parent"
@@ -35,14 +36,15 @@
       android:textSize="@dimen/text_size_body_3"
       android:textAllCaps="true"
       android:ellipsize="end"
-      android:gravity="center"/>
+      android:gravity="center"
+      tools:text="@string/remove_ads"/>
   </LinearLayout>
   <LinearLayout
     android:layout_width="wrap_content"
     android:minWidth="@dimen/ads_removal_pay_button_min_width"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/margin_base"
-    android:background="?attr/adsRemovalOptionsBg"
+    android:background="?adsRemovalOptionsBg"
     android:orientation="vertical">
     <ToggleButton
       android:id="@+id/options"
@@ -52,10 +54,9 @@
       android:textOn="@string/options_dropdown_title"
       android:textOff="@string/options_dropdown_title"
       android:textAppearance="@style/MwmTextAppearance.Body4"
-      android:background="?attr/clickableBackground"
+      android:background="?clickableBackground"
       android:gravity="start|center_vertical"
       android:drawableEnd="@drawable/ic_expand_more"
-      android:drawableRight="@drawable/ic_expand_more"
       android:padding="@dimen/margin_half_plus"
       android:textAllCaps="true"/>
     <TextView
@@ -64,7 +65,7 @@
       android:layout_height="wrap_content"
       android:minHeight="@dimen/primary_button_min_height"
       android:textAppearance="@style/MwmTextAppearance.Body4"
-      android:background="?attr/clickableBackground"
+      android:background="?clickableBackground"
       android:gravity="start|center_vertical"
       android:padding="@dimen/margin_half_plus"
       android:visibility="gone"/>
@@ -74,7 +75,7 @@
       android:layout_height="wrap_content"
       android:minHeight="@dimen/primary_button_min_height"
       android:textAppearance="@style/MwmTextAppearance.Body4"
-      android:background="?attr/clickableBackground"
+      android:background="?clickableBackground"
       android:gravity="start|center_vertical"
       android:padding="@dimen/margin_half_plus"
       android:visibility="gone"/>

--- a/android/res/layout/ads_removal_progress_container.xml
+++ b/android/res/layout/ads_removal_progress_container.xml
@@ -21,5 +21,6 @@
     android:gravity="center"
     android:singleLine="true"
     android:ellipsize="end"
-    android:textSize="@dimen/text_size_body_2"/>
+    android:textSize="@dimen/text_size_body_2"
+    tools:text="@string/remove_ads"/>
 </LinearLayout>

--- a/android/res/layout/fragment_ads_removal_purchase_dialog.xml
+++ b/android/res/layout/fragment_ads_removal_purchase_dialog.xml
@@ -4,6 +4,7 @@
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_height="match_parent"
   android:layout_width="match_parent"
+  android:background="?cardBackground"
   android:fillViewport="true">
   <RelativeLayout
     android:layout_width="match_parent"
@@ -12,6 +13,7 @@
     android:padding="@dimen/margin_base_plus"
     android:orientation="vertical">
     <TextView
+      style="?fontHeadline5"
       android:id="@+id/title"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
@@ -19,9 +21,9 @@
       android:layout_centerHorizontal="true"
       android:gravity="center"
       android:layout_gravity="center_horizontal"
-      android:textAppearance="@style/MwmTextAppearance.Title"
       android:visibility="invisible"
-      tools:visibility="visible"/>
+      tools:visibility="visible"
+      tools:text="@string/remove_ads_title"/>
     <include
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"


### PR DESCRIPTION
Половина таски https://jira.mail.ru/browse/MAPSME-15173.

Изменила стили текста на самые похоже по размеру. Ориентир https://scene.zeplin.io/project/58da0a395194ca7f0a361e61 
В фирме этих экранов нет, будут начерчены к 10.4 новые варианты.

Итог: 

![](https://sun9-14.userapi.com/EkiJU0EHLvtxFTgv1km6JKYbARP4T5f2ZXt3Kw/TZxunlidO9I.jpg)

![](https://sun9-54.userapi.com/jE6AnnhI-TWTB9pW0fVIfhtbLF9w-qFjJwllzw/kGeCByNda0A.jpg)

