### PR TITLE
[android] Reset DialogDone listener after screen rotation

### DIFF
--- a/android/src/com/mapswithme/maps/onboarding/BaseNewsFragment.java
+++ b/android/src/com/mapswithme/maps/onboarding/BaseNewsFragment.java
@@ -430,6 +430,11 @@ public abstract class BaseNewsFragment extends BaseMwmDialogFragment
     return mListener;
   }
 
+  void resetListener(@Nullable NewsDialogListener listener)
+  {
+    mListener = listener;
+  }
+
   public interface NewsDialogListener
   {
     void onDialogDone();

--- a/android/src/com/mapswithme/maps/onboarding/NewsFragment.java
+++ b/android/src/com/mapswithme/maps/onboarding/NewsFragment.java
@@ -124,7 +124,11 @@ public class NewsFragment extends BaseNewsFragment implements AlertDialogCallbac
 
     f = fm.findFragmentByTag(NewsFragment.class.getName());
     if (f != null)
-      return  true;
+    {
+      NewsFragment newsFragment = (NewsFragment) f;
+      newsFragment.resetListener(listener);
+      return true;
+    }
 
     String currentTitle = getCurrentTitleConcatenation(activity.getApplicationContext());
     String oldTitle = SharedPropertiesUtils.getWhatsNewTitleConcatenation();


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-15130
В тикете приложено видео, на котором можно заметить важный шаг для воспроизведения баги, переворот экрана. Без переворота экрана баг не воспроизводится. Проблема была в том, что при таком кейсе пересоздается сплэш активность, но листенер во фрагменте не обновляется и вызов для перехода в карту не срабатывает.