### PR TITLE
[base] Optional lock guard.

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -52,6 +52,7 @@ set(
   normalize_unicode.cpp
   non_intersecting_intervals.hpp
   observer_list.hpp
+  optional_lock_guard.hpp
   pprof.cpp
   pprof.hpp
   random.cpp

--- a/base/base_tests/CMakeLists.txt
+++ b/base/base_tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(
   newtype_test.cpp
   non_intersecting_intervals_tests.cpp
   observer_list_test.cpp
+  optional_lock_guard_tests.cpp
   range_iterator_test.cpp
   ref_counted_tests.cpp
   regexp_test.cpp

--- a/base/base_tests/optional_lock_guard_tests.cpp
+++ b/base/base_tests/optional_lock_guard_tests.cpp
@@ -1,0 +1,23 @@
+#include "testing/testing.hpp"
+
+#include "base/optional_lock_guard.hpp"
+
+#include <mutex>
+#include <optional>
+
+namespace
+{
+using namespace base;
+
+UNIT_TEST(OptionalLockGuard_Smoke)
+{
+  std::optional<std::mutex> optMtx;
+  {
+    base::OptionalLockGuard guard(optMtx);
+  }
+
+  std::optional<std::mutex> empty = std::nullopt;
+  base::OptionalLockGuard<std::mutex> guard(empty);
+}
+}  // namespace
+

--- a/base/base_tests/optional_lock_guard_tests.cpp
+++ b/base/base_tests/optional_lock_guard_tests.cpp
@@ -20,4 +20,3 @@ UNIT_TEST(OptionalLockGuard_Smoke)
   base::OptionalLockGuard<std::mutex> guard(empty);
 }
 }  // namespace
-

--- a/base/optional_lock_guard.hpp
+++ b/base/optional_lock_guard.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <mutex>
+#include <optional>
+
+namespace base
+{
+template <typename Mutex>
+class OptionalLockGuard
+{
+public:
+  explicit OptionalLockGuard(std::optional<Mutex> & optionalMutex)
+    : m_optionalGuard(optionalMutex ? std::optional<std::lock_guard<Mutex>>(*optionalMutex)
+                                    : std::nullopt)
+  {
+  }
+
+private:
+  std::optional<std::lock_guard<Mutex>> m_optionalGuard;
+};
+}

--- a/base/optional_lock_guard.hpp
+++ b/base/optional_lock_guard.hpp
@@ -18,4 +18,4 @@ public:
 private:
   std::optional<std::lock_guard<Mutex>> m_optionalGuard;
 };
-}
+}  // namespace base

--- a/xcode/base/base.xcodeproj/project.pbxproj
+++ b/xcode/base/base.xcodeproj/project.pbxproj
@@ -81,9 +81,11 @@
 		3D7815731F3A145F0068B6AC /* task_loop.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D7815711F3A145F0068B6AC /* task_loop.hpp */; };
 		3D78157B1F3D89EC0068B6AC /* waiter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D78157A1F3D89EC0068B6AC /* waiter.hpp */; };
 		3DBD7B95240FB11200ED9FE8 /* checked_cast_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3DBD7B94240FB11200ED9FE8 /* checked_cast_tests.cpp */; };
-		564BB445206E89ED00BDD211 /* fifo_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 564BB444206E89ED00BDD211 /* fifo_cache.hpp */; };
 		56290B8A206D0887003892E0 /* lru_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56290B89206D0887003892E0 /* lru_cache.hpp */; };
 		56290B8C206D0938003892E0 /* lru_cache_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56290B8B206D0937003892E0 /* lru_cache_tests.cpp */; };
+		564BB445206E89ED00BDD211 /* fifo_cache.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 564BB444206E89ED00BDD211 /* fifo_cache.hpp */; };
+		564C197B254AF896007471CE /* optional_lock_guard.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 564C197A254AF895007471CE /* optional_lock_guard.hpp */; };
+		564C197F254AF8AF007471CE /* optional_lock_guard_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 564C197E254AF8AF007471CE /* optional_lock_guard_tests.cpp */; };
 		56B1A0741E69DE4D00395022 /* random.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56B1A0711E69DE4D00395022 /* random.cpp */; };
 		56B1A0751E69DE4D00395022 /* random.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0721E69DE4D00395022 /* random.hpp */; };
 		56B1A0761E69DE4D00395022 /* small_set.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 56B1A0731E69DE4D00395022 /* small_set.hpp */; };
@@ -234,10 +236,12 @@
 		3D7815711F3A145F0068B6AC /* task_loop.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = task_loop.hpp; sourceTree = "<group>"; };
 		3D78157A1F3D89EC0068B6AC /* waiter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = waiter.hpp; sourceTree = "<group>"; };
 		3DBD7B94240FB11200ED9FE8 /* checked_cast_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = checked_cast_tests.cpp; sourceTree = "<group>"; };
-		564BB444206E89ED00BDD211 /* fifo_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fifo_cache.hpp; sourceTree = "<group>"; };
-		564BB446206E8A4D00BDD211 /* fifo_cache_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fifo_cache_test.cpp; sourceTree = "<group>"; };
 		56290B89206D0887003892E0 /* lru_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lru_cache.hpp; sourceTree = "<group>"; };
 		56290B8B206D0937003892E0 /* lru_cache_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lru_cache_tests.cpp; sourceTree = "<group>"; };
+		564BB444206E89ED00BDD211 /* fifo_cache.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = fifo_cache.hpp; sourceTree = "<group>"; };
+		564BB446206E8A4D00BDD211 /* fifo_cache_test.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fifo_cache_test.cpp; sourceTree = "<group>"; };
+		564C197A254AF895007471CE /* optional_lock_guard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = optional_lock_guard.hpp; sourceTree = "<group>"; };
+		564C197E254AF8AF007471CE /* optional_lock_guard_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = optional_lock_guard_tests.cpp; sourceTree = "<group>"; };
 		56B1A0711E69DE4D00395022 /* random.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = random.cpp; sourceTree = "<group>"; };
 		56B1A0721E69DE4D00395022 /* random.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = random.hpp; sourceTree = "<group>"; };
 		56B1A0731E69DE4D00395022 /* small_set.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = small_set.hpp; sourceTree = "<group>"; };
@@ -340,6 +344,7 @@
 		39FD26C71CC659D200AFF551 /* base_tests */ = {
 			isa = PBXGroup;
 			children = (
+				564C197E254AF8AF007471CE /* optional_lock_guard_tests.cpp */,
 				3D08987A24810A1300837783 /* linked_map_tests.cpp */,
 				3DBD7B94240FB11200ED9FE8 /* checked_cast_tests.cpp */,
 				3975D20A235F2738004D84D3 /* cancellable_tests.cpp */,
@@ -417,6 +422,7 @@
 		675341791A3F57BF00A0A8C3 /* base */ = {
 			isa = PBXGroup;
 			children = (
+				564C197A254AF895007471CE /* optional_lock_guard.hpp */,
 				3D08987824810A0B00837783 /* linked_map.hpp */,
 				3901B744235F02B2006ABD43 /* cancellable.cpp */,
 				3989E363230302EA00D63F84 /* thread_safe_queue.hpp */,
@@ -585,6 +591,7 @@
 				397DC50D22BB8EBF007126DB /* bidirectional_map.hpp in Headers */,
 				3446C6711DDCA96300146687 /* dfa_helpers.hpp in Headers */,
 				6753420C1A3F57E400A0A8C3 /* threaded_list.hpp in Headers */,
+				564C197B254AF896007471CE /* optional_lock_guard.hpp in Headers */,
 				3917FA59211E009700937DF4 /* get_time.hpp in Headers */,
 				675341DB1A3F57E400A0A8C3 /* exception.hpp in Headers */,
 				6753453E1A3F6F6A00A0A8C3 /* message.hpp in Headers */,
@@ -736,6 +743,7 @@
 				397DC51122BB8ED2007126DB /* bidirectional_map_tests.cpp in Sources */,
 				390F1C12229429A700EA58E3 /* thread_pool_computational_tests.cpp in Sources */,
 				3446C6821DDCAA7400146687 /* newtype_test.cpp in Sources */,
+				564C197F254AF8AF007471CE /* optional_lock_guard_tests.cpp in Sources */,
 				39FD27231CC65AD000AFF551 /* collection_cast_test.cpp in Sources */,
 				39FD272E1CC65AD000AFF551 /* rolling_hash_test.cpp in Sources */,
 				39FD27361CC65AD000AFF551 /* threaded_list_test.cpp in Sources */,


### PR DESCRIPTION
IndexGraph подобные классы должны работать для 2 стороннего A*, как в 2 поточном режиме, так и в однопоточном. В однопоточном режиме необходимо исключить накладные расходы на mutex. Для этого нужен класс аналогичный std::lock_guard, но такой, который берет mutex, только если он задан.

@mesozoic-drones PTAL