### PR TITLE
[android] Addid closing the filter rooms and guests when closing search.

### DIFF
--- a/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
+++ b/android/src/com/mapswithme/maps/widget/SearchToolbarController.java
@@ -349,6 +349,7 @@ public class SearchToolbarController extends ToolbarController
 
     case R.id.clear:
       onClearClick();
+      closeBottomMenu();
       break;
 
     case R.id.voice_input:
@@ -418,7 +419,6 @@ public class SearchToolbarController extends ToolbarController
       mGuestsRoomsMenuController.close();
       return true;
     }
-
     return false;
   }
 


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-15123

By design после поиска и перехода к карте пиктограмма креста означает закрытие поиска - поэтому метод добавлен в обработчик нажатия на крестик, функциональность сокрытия не сработает, если пиктограмма имеет роль чистки строки поиска, так как внутри closeBottomMenu() есть проверка на состояние нижнего меню.
