### PR TITLE
Add leap weight heuristic for cross-MWM routing

### DIFF
--- a/defines.hpp
+++ b/defines.hpp
@@ -80,6 +80,7 @@
 
 #define COUNTRIES_FILE "countries.txt"
 #define COUNTRIES_META_FILE "countries_meta.txt"
+#define LEAP_SPEEDS_FILE "leap_speeds.json"
 
 #define WORLD_FILE_NAME "World"
 #define WORLD_COASTS_FILE_NAME "WorldCoasts"

--- a/generator/generator_tests_support/routing_helpers.cpp
+++ b/generator/generator_tests_support/routing_helpers.cpp
@@ -74,7 +74,8 @@ void TestGeometryLoader::SetPassThroughAllowed(uint32_t featureId, bool passThro
 std::shared_ptr<EdgeEstimator> CreateEstimatorForCar(std::shared_ptr<TrafficStash> trafficStash)
 {
   auto const carModel = CarModelFactory({}).GetVehicleModel();
-  return EdgeEstimator::Create(VehicleType::Car, *carModel, trafficStash);
+  return EdgeEstimator::Create(VehicleType::Car, *carModel, trafficStash,
+    nullptr /* DataSource */, nullptr /* NumMwmIds */);
 }
 
 std::shared_ptr<EdgeEstimator> CreateEstimatorForCar(traffic::TrafficCache const & trafficCache)
@@ -103,4 +104,3 @@ std::unique_ptr<IndexGraph> BuildIndexGraph(std::unique_ptr<TestGeometryLoader> 
   return graph;
 }
 }  // namespace routing
-

--- a/generator/restriction_generator.cpp
+++ b/generator/restriction_generator.cpp
@@ -44,7 +44,8 @@ CreateIndexGraph(std::string const & targetPath,
 
   auto graph = std::make_unique<IndexGraph>(
       std::make_shared<Geometry>(GeometryLoader::CreateFromFile(mwmPath, vehicleModel)),
-      EdgeEstimator::Create(VehicleType::Car, *vehicleModel, nullptr /* trafficStash */));
+      EdgeEstimator::Create(VehicleType::Car, *vehicleModel, nullptr /* trafficStash */,
+        nullptr /* dataSource */, nullptr /* numMvmIds */));
 
   DeserializeIndexGraph(mwmValue, VehicleType::Car, *graph);
 
@@ -108,7 +109,7 @@ void SerializeRestrictions(RestrictionCollector & restrictionCollector,
 
     CHECK_GREATER_OR_EQUAL(i, 1, ("Unexpected overflow."));
     auto const prevType = RestrictionHeader::kRestrictionTypes[i - 1];
-    header.SetNumberOf(prevType, 
+    header.SetNumberOf(prevType,
                        base::checked_cast<uint32_t>(std::distance(prevTypeEndIt, firstNextType)));
 
     prevTypeEndIt = firstNextType;

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -534,7 +534,9 @@ void FillWeights(string const & path, string const & mwmFile, string const & cou
   routing::IndexGraph graph(make_shared<routing::Geometry>(
                                 routing::GeometryLoader::CreateFromFile(mwmFile, vehicleModel), mwmNumRoads),
                             routing::EdgeEstimator::Create(routing::VehicleType::Car, *vehicleModel,
-                                                           nullptr /* trafficStash */));
+                                                           nullptr /* trafficStash */,
+                                                           nullptr /* dataSource */,
+                                                           nullptr /* numMvmIds */));
   DeserializeIndexGraph(mwmValue, routing::VehicleType::Car, graph);
 
   map<routing::Segment, map<routing::Segment, routing::RouteWeight>> weights;

--- a/indexer/feature_meta.hpp
+++ b/indexer/feature_meta.hpp
@@ -197,7 +197,8 @@ public:
     RD_PHONE_FORMAT,     // list of strings in "+N NNN NN-NN-NN" format
     RD_POSTCODE_FORMAT,  // list of strings in "AAA ANN" format
     RD_PUBLIC_HOLIDAYS,  // fixed PH dates
-    RD_ALLOW_HOUSENAMES  // 'y' if housenames are commonly used
+    RD_ALLOW_HOUSENAMES, // 'y' if housenames are commonly used
+    RD_LEAP_WEIGHT_SPEED // speed factor for leap weight computation
   };
 
   // Special values for month references in public holiday definitions.
@@ -234,6 +235,19 @@ public:
 
   void AddPublicHoliday(int8_t month, int8_t offset);
   // No public holidays getters until we know what to do with these.
+
+  void SetLeapWeightSpeed(double speedValue)
+  {
+    std::string strValue = std::to_string(speedValue);
+    MetadataBase::Set(Type::RD_LEAP_WEIGHT_SPEED, strValue);
+  }
+
+  double GetLeapWeightSpeed(double defaultValue) const
+  {
+    if (Has(Type::RD_LEAP_WEIGHT_SPEED))
+      return std::stod(Get(Type::RD_LEAP_WEIGHT_SPEED));
+    return defaultValue;
+  }
 };
 
 // Prints types in osm-friendly format.

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -146,6 +146,8 @@ double EdgeEstimator::ComputeDefaultLeapWeightSpeed() const
 
 double EdgeEstimator::LoadLeapWeightSpeed(NumMwmId mwmId)
 {
+  double leapWeightSpeed = ComputeDefaultLeapWeightSpeed();
+
   if (m_dataSourcePtr)
   {
     MwmSet::MwmHandle handle =
@@ -154,10 +156,13 @@ double EdgeEstimator::LoadLeapWeightSpeed(NumMwmId mwmId)
       MYTHROW(RoutingException, ("Mwm", m_numMwmIds->GetFile(mwmId), "cannot be loaded."));
 
     if (handle.GetInfo())
-      return handle.GetInfo()->GetRegionData().GetLeapWeightSpeed(m_maxWeightSpeedMpS / 2.0);
+      leapWeightSpeed = handle.GetInfo()->GetRegionData().GetLeapWeightSpeed(leapWeightSpeed);
   }
 
-  return ComputeDefaultLeapWeightSpeed();
+  if (leapWeightSpeed > m_maxWeightSpeedMpS)
+    leapWeightSpeed = m_maxWeightSpeedMpS;
+
+  return leapWeightSpeed;
 }
 
 double EdgeEstimator::GetLeapWeightSpeed(NumMwmId mwmId)

--- a/routing/edge_estimator.cpp
+++ b/routing/edge_estimator.cpp
@@ -138,10 +138,9 @@ double EdgeEstimator::CalcHeuristic(ms::LatLon const & from, ms::LatLon const & 
 
 double EdgeEstimator::ComputeDefaultLeapWeightSpeed() const
 {
-  // Let us assume for the time being that
-  // leap edges will be added with a half of max speed
-  // if no leap speed provided
-  return m_maxWeightSpeedMpS / 2.0;
+  // Scale coefficient computed as average ratio of escape/enter speed
+  // to max MWM speed across all MWMs.
+  return m_maxWeightSpeedMpS / 1.76;
 }
 
 double EdgeEstimator::LoadLeapWeightSpeed(NumMwmId mwmId)
@@ -302,8 +301,7 @@ double CarEstimator::GetFerryLandingPenalty(Purpose purpose) const
 {
   switch (purpose)
   {
-  case Purpose::Weight:
-    return 40 * 60;  // seconds
+  case Purpose::Weight: return 40 * 60;  // seconds
   // Based on https://confluence.mail.ru/display/MAPSME/Ferries
   case Purpose::ETA: return 20 * 60;  // seconds
   }

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -291,7 +291,8 @@ IndexRouter::IndexRouter(VehicleType vehicleType, bool loadAltitudes,
                 m_vehicleModelFactory)
   , m_estimator(EdgeEstimator::Create(
         m_vehicleType, CalcMaxSpeed(*m_numMwmIds, *m_vehicleModelFactory, m_vehicleType),
-        CalcOffroadSpeed(*m_vehicleModelFactory), m_trafficStash))
+        CalcOffroadSpeed(*m_vehicleModelFactory), m_trafficStash,
+        &dataSource, m_numMwmIds))
   , m_directionsEngine(CreateDirectionsEngine(m_vehicleType, m_numMwmIds, m_dataSource))
   , m_countryParentNameGetterFn(countryParentNameGetterFn)
 {

--- a/routing/leaps_graph.cpp
+++ b/routing/leaps_graph.cpp
@@ -87,7 +87,7 @@ void LeapsGraph::GetEdgesListFromStart(Segment const & segment, std::vector<Segm
     for (auto const & exit : exits)
     {
       auto const & exitFrontPoint = m_starter.GetPoint(exit, true /* front */);
-      auto const weight = m_starter.GetGraph().CalcLeapWeight(m_startPoint, exitFrontPoint);
+      auto const weight = m_starter.GetGraph().CalcLeapWeight(m_startPoint, exitFrontPoint, mwmId);
 
       edges.emplace_back(exit, weight);
     }
@@ -103,7 +103,7 @@ void LeapsGraph::GetEdgesListToFinish(Segment const & segment, std::vector<Segme
     for (auto const & enter : enters)
     {
       auto const & enterFrontPoint = m_starter.GetPoint(enter, true /* front */);
-      auto const weight = m_starter.GetGraph().CalcLeapWeight(enterFrontPoint, m_finishPoint);
+      auto const weight = m_starter.GetGraph().CalcLeapWeight(enterFrontPoint, m_finishPoint, mwmId);
 
       edges.emplace_back(enter, weight);
     }

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -161,9 +161,10 @@ RouteWeight SingleVehicleWorldGraph::CalcSegmentWeight(Segment const & segment,
 }
 
 RouteWeight SingleVehicleWorldGraph::CalcLeapWeight(ms::LatLon const & from,
-                                                    ms::LatLon const & to) const
+                                                    ms::LatLon const & to,
+                                                    NumMwmId mwmId) const
 {
-  return RouteWeight(m_estimator->CalcLeapWeight(from, to));
+  return RouteWeight(m_estimator->CalcLeapWeight(from, to, mwmId));
 }
 
 RouteWeight SingleVehicleWorldGraph::CalcOffroadWeight(ms::LatLon const & from,
@@ -271,7 +272,7 @@ NumMwmId GetCommonMwmInChain(vector<VertexType> const & chain)
 }
 
 template <typename VertexType>
-bool 
+bool
 SingleVehicleWorldGraph::AreWavesConnectibleImpl(Parents<VertexType> const & forwardParents,
                                                  VertexType const & commonVertex,
                                                  Parents<VertexType> const & backwardParents,

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -63,7 +63,7 @@ public:
   RouteWeight HeuristicCostEstimate(ms::LatLon const & from, ms::LatLon const & to) override;
 
   RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) override;
-  RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const override;
+  RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to, NumMwmId mwmId) const override;
   RouteWeight CalcOffroadWeight(ms::LatLon const & from, ms::LatLon const & to,
                                 EdgeEstimator::Purpose purpose) const override;
   double CalculateETA(Segment const & from, Segment const & to) override;

--- a/routing/transit_world_graph.cpp
+++ b/routing/transit_world_graph.cpp
@@ -129,9 +129,9 @@ RouteWeight TransitWorldGraph::CalcSegmentWeight(Segment const & segment,
       segment, GetRealRoadGeometry(segment.GetMwmId(), segment.GetFeatureId()), purpose));
 }
 
-RouteWeight TransitWorldGraph::CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const
+RouteWeight TransitWorldGraph::CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to, NumMwmId mwmId) const
 {
-  return RouteWeight(m_estimator->CalcLeapWeight(from, to));
+  return RouteWeight(m_estimator->CalcLeapWeight(from, to, mwmId));
 }
 
 RouteWeight TransitWorldGraph::CalcOffroadWeight(ms::LatLon const & from,

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -64,7 +64,7 @@ public:
   RouteWeight HeuristicCostEstimate(ms::LatLon const & from, ms::LatLon const & to) override;
 
   RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) override;
-  RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const override;
+  RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to, NumMwmId mwmId) const override;
   RouteWeight CalcOffroadWeight(ms::LatLon const & from, ms::LatLon const & to,
                                 EdgeEstimator::Purpose purpose) const override;
   double CalculateETA(Segment const & from, Segment const & to) override;

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -82,7 +82,7 @@ public:
   virtual RouteWeight CalcSegmentWeight(Segment const & segment,
                                         EdgeEstimator::Purpose purpose) = 0;
 
-  virtual RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const = 0;
+  virtual RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to, NumMwmId mwmId) const = 0;
 
   virtual RouteWeight CalcOffroadWeight(ms::LatLon const & from, ms::LatLon const & to,
                                         EdgeEstimator::Purpose purpose) const = 0;

--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -406,7 +406,8 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
     MatchedTrackPointToMoveType pointToMoveType(FilesContainerR(make_unique<FileReader>(mwmFile)), *vehicleModel);
     Geometry geometry(GeometryLoader::CreateFromFile(mwmFile, vehicleModel));
     auto const vehicleType = VehicleType::Car;
-    auto const edgeEstimator = EdgeEstimator::Create(vehicleType, *vehicleModel, nullptr /* trafficStash */);
+    auto const edgeEstimator = EdgeEstimator::Create(vehicleType, *vehicleModel,
+      nullptr /* trafficStash */, &dataSource, numMwmIds);
     auto indexGraphLoader = IndexGraphLoader::Create(vehicleType, false /* loadAltitudes */, numMwmIds,
                                                      carModelFactory, edgeEstimator, dataSource);
 

--- a/track_analyzing/track_analyzer/cmd_tracks.cpp
+++ b/track_analyzing/track_analyzer/cmd_tracks.cpp
@@ -149,7 +149,8 @@ void CmdTracks(string const & filepath, string const & trackExtension, StringFil
         GeometryLoader::CreateFromFile(GetCurrentVersionMwmFile(storage, mwmName), vehicleModel));
 
     shared_ptr<EdgeEstimator> estimator =
-        EdgeEstimator::Create(VehicleType::Car, *vehicleModel, nullptr /* trafficStash */);
+        EdgeEstimator::Create(VehicleType::Car, *vehicleModel,
+          nullptr /* trafficStash */, nullptr /* dataSource */, nullptr /* numMwmIds */);
 
     for (auto it : userToMatchedTracks)
     {

--- a/track_analyzing/track_matcher.cpp
+++ b/track_analyzing/track_matcher.cpp
@@ -70,7 +70,8 @@ TrackMatcher::TrackMatcher(storage::Storage const & storage, NumMwmId mwmId,
       make_shared<Geometry>(GeometryLoader::Create(m_dataSource, handle, m_vehicleModel,
                                                    AttrLoader(m_dataSource, handle),
                                                    false /* loadAltitudes */)),
-      EdgeEstimator::Create(VehicleType::Car, *m_vehicleModel, nullptr /* trafficStash */));
+      EdgeEstimator::Create(VehicleType::Car, *m_vehicleModel, nullptr /* trafficStash */,
+        nullptr /* dataSource */, nullptr /* numMvmIds */));
 
   DeserializeIndexGraph(*handle.GetValue(), VehicleType::Car, *m_graph);
 }


### PR DESCRIPTION
Добавлено сохранение и загрузка коэффициентов средней скорости движения к точкам въезда/выезда при кросс-MWM роутинге.