### PR TITLE
[android] reset layer mode when tutorial is shown

### DIFF
--- a/android/src/com/mapswithme/maps/MwmActivity.java
+++ b/android/src/com/mapswithme/maps/MwmActivity.java
@@ -2550,6 +2550,8 @@ public class MwmActivity extends BaseMwmFragmentActivity
   public void setTutorial(@NonNull Tutorial tutorial)
   {
     mTutorial = tutorial;
+    if (mTutorial.isLayer())
+      mToggleMapLayerController.turnOff();
     mToggleMapLayerController.setTutorial(tutorial);
   }
 

--- a/android/src/com/mapswithme/maps/tips/Tutorial.java
+++ b/android/src/com/mapswithme/maps/tips/Tutorial.java
@@ -183,4 +183,9 @@ public enum Tutorial
     LOGGER.d(TAG, "tipsApi = " + tipsApi);
     return tipsApi;
   }
+
+  public boolean isLayer()
+  {
+    return this == SUBWAY || this == ISOLINES;
+  }
 }


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-15008
Проблема была в том, что показываемый туториал не соответствовал текущему выбранному слою. Решено сбрасывать слой при отображении туториала. При таком подходе туториал отображается верно, подсвечивая нужную кнопку. по нажатию на кнопку сразу выбирается слой, который соответствует показанному туториалу