### PR TITLE
[generator_integration_tests] Set m_genInfo.m_cacheDir.

### DIFF
--- a/generator/generator_integration_tests/features_tests.cpp
+++ b/generator/generator_integration_tests/features_tests.cpp
@@ -461,6 +461,7 @@ private:
     m_genInfo.SetNodeStorageType("map");
     m_genInfo.SetOsmFileType("o5m");
     m_genInfo.m_intermediateDir = base::JoinPath(m_testPath, archiveName, "intermediate_data");
+    m_genInfo.m_cacheDir = base::JoinPath(m_testPath, archiveName, "intermediate_data");
     m_genInfo.m_targetDir = m_genInfo.m_intermediateDir;
     m_genInfo.m_tmpDir = base::JoinPath(m_genInfo.m_intermediateDir, "tmp");
     m_genInfo.m_osmFileName = base::JoinPath(m_testPath, "planet.o5m");


### PR DESCRIPTION
сейчас тесты падают с 

```
<<<Exception thrown [ Reader::OpenException /var/lib/jenkins/workspace/GeneratorIntegration/omim/coding/internal/file_data.cpp:50, "nodes.dat.short; Read; No such file or directory" ].>>>
```