### PR TITLE
[android] Rework of all pass viewPager

### DIFF
--- a/android/res/layout-w600dp/pager_fragment_bookmarks_all_subscription.xml
+++ b/android/res/layout-w600dp/pager_fragment_bookmarks_all_subscription.xml
@@ -9,26 +9,12 @@
     android:id="@+id/img1"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:scaleType="centerCrop"
-    android:src="@drawable/all_pass_premium_63" />
+    android:scaleType="centerCrop" />
   <ImageView
     android:id="@+id/img2"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:scaleType="centerCrop"
-    android:src="@drawable/all_pass_premium_61" />
-  <ImageView
-    android:id="@+id/img3"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:scaleType="centerCrop"
-    android:src="@drawable/all_pass_premium_62" />
-  <ImageView
-    android:id="@+id/img4"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:scaleType="centerCrop"
-    android:src="@drawable/all_pass_premium_60" />
+    android:scaleType="centerCrop" />
   <androidx.core.widget.NestedScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/android/res/layout/pager_fragment_bookmarks_all_subscription.xml
+++ b/android/res/layout/pager_fragment_bookmarks_all_subscription.xml
@@ -9,26 +9,12 @@
     android:id="@+id/img1"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:scaleType="centerCrop"
-    android:src="@drawable/all_pass_premium_63" />
+    android:scaleType="centerCrop" />
   <ImageView
     android:id="@+id/img2"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:scaleType="centerCrop"
-    android:src="@drawable/all_pass_premium_61" />
-  <ImageView
-    android:id="@+id/img3"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:scaleType="centerCrop"
-    android:src="@drawable/all_pass_premium_62" />
-  <ImageView
-    android:id="@+id/img4"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:scaleType="centerCrop"
-    android:src="@drawable/all_pass_premium_60" />
+    android:scaleType="centerCrop" />
   <androidx.core.widget.NestedScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/android/src/com/mapswithme/maps/onboarding/NewsFragment.java
+++ b/android/src/com/mapswithme/maps/onboarding/NewsFragment.java
@@ -19,6 +19,7 @@ import com.mapswithme.maps.bookmarks.data.BookmarkCategory;
 import com.mapswithme.maps.bookmarks.data.BookmarkManager;
 import com.mapswithme.maps.dialog.AlertDialogCallback;
 import com.mapswithme.maps.downloader.UpdaterDialogFragment;
+import com.mapswithme.maps.purchase.BookmarkAllSubscriptionData;
 import com.mapswithme.maps.purchase.BookmarksAllSubscriptionActivity;
 import com.mapswithme.maps.purchase.PurchaseUtils;
 import com.mapswithme.util.Counters;
@@ -26,6 +27,11 @@ import com.mapswithme.util.SharedPropertiesUtils;
 import com.mapswithme.util.UTM;
 import com.mapswithme.util.UiUtils;
 import com.mapswithme.util.statistics.Statistics;
+
+import static com.mapswithme.maps.purchase.BookmarksAllSubscriptionPage.BOOKMARKS;
+import static com.mapswithme.maps.purchase.BookmarksAllSubscriptionPage.ELEVATION;
+import static com.mapswithme.maps.purchase.BookmarksAllSubscriptionPage.GUIDES;
+import static com.mapswithme.maps.purchase.BookmarksAllSubscriptionPage.LONELY;
 
 public class NewsFragment extends BaseNewsFragment implements AlertDialogCallback
 {
@@ -85,7 +91,11 @@ public class NewsFragment extends BaseNewsFragment implements AlertDialogCallbac
       UiUtils.hide(view);
       BookmarksAllSubscriptionActivity.startForResult(NewsFragment.this,
                                                       PurchaseUtils.REQ_CODE_PAY_SUBSCRIPTION,
-                                                      Statistics.ParamValue.WHATSNEW);
+                                                      Statistics.ParamValue.WHATSNEW,
+                                                      new BookmarkAllSubscriptionData(LONELY,
+                                                                                      GUIDES,
+                                                                                      BOOKMARKS,
+                                                                                      ELEVATION));
     }
   }
 

--- a/android/src/com/mapswithme/maps/purchase/BookmarkAllSubscriptionData.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarkAllSubscriptionData.java
@@ -4,15 +4,18 @@ import android.os.Parcel;
 import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class BookmarkAllSubscriptionData implements Parcelable
 {
   @SuppressWarnings("unused")
-  public static final Parcelable.Creator<BookmarkAllSubscriptionData> CREATOR = new Parcelable.Creator<BookmarkAllSubscriptionData>()
+  public static final Parcelable.Creator<BookmarkAllSubscriptionData> CREATOR =
+      new Parcelable.Creator<BookmarkAllSubscriptionData>()
   {
     @Override
     public BookmarkAllSubscriptionData createFromParcel(Parcel in)
@@ -26,12 +29,12 @@ public class BookmarkAllSubscriptionData implements Parcelable
       return new BookmarkAllSubscriptionData[size];
     }
   };
-  @NonNull
+  @Nullable
   private final List<BookmarksAllSubscriptionPage> mOrderList;
 
   public BookmarkAllSubscriptionData(@NonNull List<BookmarksAllSubscriptionPage> orderList)
   {
-    mOrderList = orderList;
+    mOrderList = Collections.unmodifiableList(orderList);
   }
 
   public BookmarkAllSubscriptionData(@NonNull BookmarksAllSubscriptionPage... arguments)
@@ -60,7 +63,8 @@ public class BookmarkAllSubscriptionData implements Parcelable
   @NonNull
   public List<BookmarksAllSubscriptionPage> getOrderList()
   {
-    return mOrderList;
+
+    return mOrderList != null ? mOrderList : Collections.emptyList();
   }
 
   @Override

--- a/android/src/com/mapswithme/maps/purchase/BookmarkAllSubscriptionData.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarkAllSubscriptionData.java
@@ -1,0 +1,90 @@
+package com.mapswithme.maps.purchase;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class BookmarkAllSubscriptionData implements Parcelable
+{
+  @SuppressWarnings("unused")
+  public static final Parcelable.Creator<BookmarkAllSubscriptionData> CREATOR = new Parcelable.Creator<BookmarkAllSubscriptionData>()
+  {
+    @Override
+    public BookmarkAllSubscriptionData createFromParcel(Parcel in)
+    {
+      return new BookmarkAllSubscriptionData(in);
+    }
+
+    @Override
+    public BookmarkAllSubscriptionData[] newArray(int size)
+    {
+      return new BookmarkAllSubscriptionData[size];
+    }
+  };
+  @NonNull
+  private final List<BookmarksAllSubscriptionPage> mOrderList;
+
+  public BookmarkAllSubscriptionData(@NonNull List<BookmarksAllSubscriptionPage> orderList)
+  {
+    mOrderList = orderList;
+  }
+
+  public BookmarkAllSubscriptionData(@NonNull BookmarksAllSubscriptionPage... arguments)
+  {
+    this(Arrays.asList(arguments));
+  }
+
+  protected BookmarkAllSubscriptionData(Parcel in)
+  {
+    if (in.readByte() == 0x01)
+    {
+      List<Integer> indexList = new ArrayList<>();
+      in.readList(indexList, Integer.class.getClassLoader());
+      mOrderList = new ArrayList<>(indexList.size());
+      for (Integer index : indexList)
+      {
+        mOrderList.add(BookmarksAllSubscriptionPage.values()[index]);
+      }
+    }
+    else
+    {
+      mOrderList = null;
+    }
+  }
+
+  @NonNull
+  public List<BookmarksAllSubscriptionPage> getOrderList()
+  {
+    return mOrderList;
+  }
+
+  @Override
+  public int describeContents()
+  {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel dest, int flags)
+  {
+    if (mOrderList == null)
+    {
+      dest.writeByte((byte) (0x00));
+    }
+    else
+    {
+      dest.writeByte((byte) (0x01));
+      List<Integer> indexArray = new ArrayList<>(mOrderList.size());
+      for (BookmarksAllSubscriptionPage page : mOrderList)
+      {
+        indexArray.add(page.ordinal());
+      }
+      dest.writeList(indexArray);
+    }
+  }
+}

--- a/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionActivity.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionActivity.java
@@ -54,7 +54,7 @@ public class BookmarksAllSubscriptionActivity extends BaseMwmFragmentActivity
     fragment.startActivityForResult(intent, requestCode);
   }
 
-  private static void addBookmarkAllSubscriptionExtra(Intent intent)
+  private static void addBookmarkAllSubscriptionExtra(@NonNull Intent intent)
   {
     intent.putExtra(BookmarksAllSubscriptionFragment.BUNDLE_DATA,
                     new BookmarkAllSubscriptionData(GUIDES, BOOKMARKS, ELEVATION, LONELY));

--- a/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionActivity.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionActivity.java
@@ -44,6 +44,16 @@ public class BookmarksAllSubscriptionActivity extends BaseMwmFragmentActivity
     fragment.startActivityForResult(intent, requestCode);
   }
 
+  public static void startForResult(@NonNull Fragment fragment, int requestCode,
+                                    @NonNull String from, @NonNull BookmarkAllSubscriptionData data)
+  {
+    Intent intent = new Intent(fragment.getActivity(), BookmarksAllSubscriptionActivity.class);
+    intent.putExtra(AbstractBookmarkSubscriptionFragment.EXTRA_FROM, from)
+          .setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+    intent.putExtra(BookmarksAllSubscriptionFragment.BUNDLE_DATA, data);
+    fragment.startActivityForResult(intent, requestCode);
+  }
+
   private static void addBookmarkAllSubscriptionExtra(Intent intent)
   {
     intent.putExtra(BookmarksAllSubscriptionFragment.BUNDLE_DATA,

--- a/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionActivity.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionActivity.java
@@ -8,11 +8,17 @@ import androidx.fragment.app.FragmentActivity;
 import com.mapswithme.maps.R;
 import com.mapswithme.maps.base.BaseMwmFragmentActivity;
 
+import static com.mapswithme.maps.purchase.BookmarksAllSubscriptionPage.GUIDES;
+import static com.mapswithme.maps.purchase.BookmarksAllSubscriptionPage.LONELY;
+import static com.mapswithme.maps.purchase.BookmarksAllSubscriptionPage.BOOKMARKS;
+import static com.mapswithme.maps.purchase.BookmarksAllSubscriptionPage.ELEVATION;
+
 public class BookmarksAllSubscriptionActivity extends BaseMwmFragmentActivity
 {
   public static void startForResult(@NonNull FragmentActivity activity)
   {
     Intent intent = new Intent(activity, BookmarksAllSubscriptionActivity.class);
+    addBookmarkAllSubscriptionExtra(intent);
     activity.startActivityForResult(intent, PurchaseUtils.REQ_CODE_PAY_SUBSCRIPTION);
   }
 
@@ -34,6 +40,13 @@ public class BookmarksAllSubscriptionActivity extends BaseMwmFragmentActivity
     Intent intent = new Intent(fragment.getActivity(), BookmarksAllSubscriptionActivity.class);
     intent.putExtra(AbstractBookmarkSubscriptionFragment.EXTRA_FROM, from)
           .setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+    addBookmarkAllSubscriptionExtra(intent);
     fragment.startActivityForResult(intent, requestCode);
+  }
+
+  private static void addBookmarkAllSubscriptionExtra(Intent intent)
+  {
+    intent.putExtra(BookmarksAllSubscriptionFragment.BUNDLE_DATA,
+                    new BookmarkAllSubscriptionData(GUIDES, BOOKMARKS, ELEVATION, LONELY));
   }
 }

--- a/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionFragment.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionFragment.java
@@ -48,9 +48,8 @@ public class BookmarksAllSubscriptionFragment extends AbstractBookmarkSubscripti
   public void onCreate(@Nullable Bundle savedInstanceState)
   {
     super.onCreate(savedInstanceState);
-    BookmarkAllSubscriptionData data = Objects
-        .requireNonNull(getArguments().getParcelable(BUNDLE_DATA));
-    mPageOrderList = data.getOrderList();
+    BookmarkAllSubscriptionData data = requireArguments().getParcelable(BUNDLE_DATA);
+    mPageOrderList = Objects.requireNonNull(data).getOrderList();
   }
 
   @Nullable

--- a/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionFragment.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionFragment.java
@@ -18,11 +18,18 @@ import com.mapswithme.maps.widget.ParallaxBackgroundViewPager;
 import com.mapswithme.util.UiUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 @SuppressWarnings("WeakerAccess")
 public class BookmarksAllSubscriptionFragment extends AbstractBookmarkSubscriptionFragment
 {
+  public static final String BUNDLE_DATA = "data";
+
+  @NonNull
+  private List<BookmarksAllSubscriptionPage> mPageOrderList = Collections.emptyList();
+
   @NonNull
   @Override
   PurchaseController<PurchaseCallback> createPurchaseController()
@@ -35,6 +42,15 @@ public class BookmarksAllSubscriptionFragment extends AbstractBookmarkSubscripti
   SubscriptionFragmentDelegate createFragmentDelegate(@NonNull AbstractBookmarkSubscriptionFragment fragment)
   {
     return new TwoButtonsSubscriptionFragmentDelegate(fragment);
+  }
+
+  @Override
+  public void onCreate(@Nullable Bundle savedInstanceState)
+  {
+    super.onCreate(savedInstanceState);
+    BookmarkAllSubscriptionData data = Objects
+        .requireNonNull(getArguments().getParcelable(BUNDLE_DATA));
+    mPageOrderList = data.getOrderList();
   }
 
   @Nullable
@@ -72,45 +88,60 @@ public class BookmarksAllSubscriptionFragment extends AbstractBookmarkSubscripti
 
   private void initViewPager(@NonNull View root)
   {
-    final List<Integer> items = makeItems();
-
+    final List<BookmarksAllSubscriptionPageData> items = makeItems();
     ParallaxBackgroundViewPager viewPager = root.findViewById(R.id.pager);
-    PagerAdapter adapter = new ParallaxFragmentPagerAdapter(requireFragmentManager(),
-                                                            items);
+    PagerAdapter adapter = new ParallaxFragmentPagerAdapter(requireFragmentManager(), items);
     viewPager.setAdapter(adapter);
-    ViewPager.OnPageChangeListener listener = new ParallaxBackgroundPageListener(requireActivity(),
-                                                                                 viewPager, items);
+    ViewPager.OnPageChangeListener listener =
+        new ParallaxBackgroundPageListener(items, root.findViewById(R.id.img2),
+                                           root.findViewById(R.id.img1));
     viewPager.addOnPageChangeListener(listener);
     viewPager.startAutoScroll();
   }
 
   @NonNull
-  private static List<Integer> makeItems()
+  private List<BookmarksAllSubscriptionPageData> makeItems()
   {
-    List<Integer> items = new ArrayList<>();
-    items.add(R.id.img4);
-    items.add(R.id.img3);
-    items.add(R.id.img2);
-    items.add(R.id.img1);
+    List<BookmarksAllSubscriptionPageData> items = new ArrayList<>();
+    for (BookmarksAllSubscriptionPage page : mPageOrderList)
+    {
+      int resId = 0;
+      switch (page)
+      {
+        case GUIDES:
+          resId = R.drawable.all_pass_premium_60;
+          break;
+        case BOOKMARKS:
+          resId = R.drawable.all_pass_premium_62;
+          break;
+        case ELEVATION:
+          resId = R.drawable.all_pass_premium_61;
+          break;
+        case LONELY:
+          resId = R.drawable.all_pass_premium_63;
+          break;
+      }
+      items.add(new BookmarksAllSubscriptionPageData(resId, page));
+    }
     return items;
   }
 
-  private class ParallaxFragmentPagerAdapter extends FragmentPagerAdapter
+  private static class ParallaxFragmentPagerAdapter extends FragmentPagerAdapter
   {
     @NonNull
-    private final List<Integer> mItems;
+    private final List<BookmarksAllSubscriptionPageData> mItems;
 
     ParallaxFragmentPagerAdapter(@NonNull FragmentManager fragmentManager,
-                                 @NonNull List<Integer> items)
+                                 @NonNull List<BookmarksAllSubscriptionPageData> items)
     {
-      super(fragmentManager);
+      super(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
       mItems = items;
     }
 
     @Override
     public Fragment getItem(int i)
     {
-      return BookmarksAllSubscriptionPageFragment.newInstance(i);
+      return BookmarksAllSubscriptionPageFragment.newInstance(mItems.get(i));
     }
 
     @Override

--- a/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionPage.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionPage.java
@@ -5,13 +5,13 @@ import com.mapswithme.maps.R;
 
 public enum BookmarksAllSubscriptionPage
 {
-  FIRST(R.string.all_pass_subscription_message_title,
-        R.string.all_pass_subscription_message_subtitle),
-  SECOND(R.string.all_pass_subscription_message_title_3,
-         R.string.all_pass_subscription_message_subtitle_3),
-  THIRD(R.string.all_pass_subscription_message_title_2,
-        R.string.all_pass_subscription_message_subtitle_2),
-  FOURTH(R.string.all_pass_subscription_message_title_4,
+  GUIDES(R.string.all_pass_subscription_message_title,
+         R.string.all_pass_subscription_message_subtitle),
+  BOOKMARKS(R.string.all_pass_subscription_message_title_3,
+            R.string.all_pass_subscription_message_subtitle_3),
+  ELEVATION(R.string.all_pass_subscription_message_title_2,
+            R.string.all_pass_subscription_message_subtitle_2),
+  LONELY(R.string.all_pass_subscription_message_title_4,
          R.string.all_pass_subscription_message_subtitle_4);
 
   @StringRes

--- a/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionPageData.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionPageData.java
@@ -1,0 +1,68 @@
+package com.mapswithme.maps.purchase;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+
+public class BookmarksAllSubscriptionPageData implements Parcelable
+{
+  @SuppressWarnings("unused")
+  public static final Parcelable.Creator<BookmarksAllSubscriptionPageData> CREATOR = new Parcelable.Creator<BookmarksAllSubscriptionPageData>()
+  {
+    @Override
+    public BookmarksAllSubscriptionPageData createFromParcel(Parcel in)
+    {
+      return new BookmarksAllSubscriptionPageData(in);
+    }
+
+    @Override
+    public BookmarksAllSubscriptionPageData[] newArray(int size)
+    {
+      return new BookmarksAllSubscriptionPageData[size];
+    }
+  };
+  @NonNull
+  @DrawableRes
+  private final int mImageId;
+  @NonNull
+  private final BookmarksAllSubscriptionPage mPage;
+
+  public BookmarksAllSubscriptionPageData(@DrawableRes int imageId, @NonNull BookmarksAllSubscriptionPage page)
+  {
+    mImageId = imageId;
+    mPage = page;
+  }
+
+  protected BookmarksAllSubscriptionPageData(Parcel in)
+  {
+    mImageId = in.readInt();
+    mPage = BookmarksAllSubscriptionPage.values()[in.readInt()];
+  }
+
+  @NonNull
+  public int getImageId()
+  {
+    return mImageId;
+  }
+
+  @NonNull
+  public BookmarksAllSubscriptionPage getPage()
+  {
+    return mPage;
+  }
+
+  @Override
+  public int describeContents()
+  {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel dest, int flags)
+  {
+    dest.writeInt(mImageId);
+    dest.writeInt(mPage.ordinal());
+  }
+}

--- a/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionPageData.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionPageData.java
@@ -9,7 +9,8 @@ import androidx.annotation.NonNull;
 public class BookmarksAllSubscriptionPageData implements Parcelable
 {
   @SuppressWarnings("unused")
-  public static final Parcelable.Creator<BookmarksAllSubscriptionPageData> CREATOR = new Parcelable.Creator<BookmarksAllSubscriptionPageData>()
+  public static final Parcelable.Creator<BookmarksAllSubscriptionPageData> CREATOR =
+      new Parcelable.Creator<BookmarksAllSubscriptionPageData>()
   {
     @Override
     public BookmarksAllSubscriptionPageData createFromParcel(Parcel in)
@@ -23,7 +24,7 @@ public class BookmarksAllSubscriptionPageData implements Parcelable
       return new BookmarksAllSubscriptionPageData[size];
     }
   };
-  @NonNull
+
   @DrawableRes
   private final int mImageId;
   @NonNull
@@ -41,7 +42,7 @@ public class BookmarksAllSubscriptionPageData implements Parcelable
     mPage = BookmarksAllSubscriptionPage.values()[in.readInt()];
   }
 
-  @NonNull
+  @DrawableRes
   public int getImageId()
   {
     return mImageId;

--- a/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionPageFragment.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionPageFragment.java
@@ -24,8 +24,8 @@ public class BookmarksAllSubscriptionPageFragment extends Fragment
   public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
                            @Nullable Bundle savedInstanceState)
   {
-    BookmarksAllSubscriptionPageData data = Objects.requireNonNull(getArguments()).getParcelable(BUNDLE_DATA);
-    BookmarksAllSubscriptionPage page = data.getPage();
+    BookmarksAllSubscriptionPageData data = requireArguments().getParcelable(BUNDLE_DATA);
+    BookmarksAllSubscriptionPage page = Objects.requireNonNull(data).getPage();
     FragmentBookmarksAllSubscriptionBinding binding = makeBinding(inflater, container);
     binding.setPage(page);
     binding.description.setText(Html.fromHtml(getString(page.getDescriptionId())));
@@ -40,7 +40,7 @@ public class BookmarksAllSubscriptionPageFragment extends Fragment
   }
 
   @NonNull
-  static Fragment newInstance(BookmarksAllSubscriptionPageData data)
+  static Fragment newInstance(@NonNull BookmarksAllSubscriptionPageData data)
   {
     BookmarksAllSubscriptionPageFragment fragment = new BookmarksAllSubscriptionPageFragment();
     Bundle args = new Bundle();

--- a/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionPageFragment.java
+++ b/android/src/com/mapswithme/maps/purchase/BookmarksAllSubscriptionPageFragment.java
@@ -15,17 +15,17 @@ import com.mapswithme.maps.databinding.FragmentBookmarksAllSubscriptionBinding;
 
 import java.util.Objects;
 
+import static com.mapswithme.maps.purchase.BookmarksAllSubscriptionFragment.BUNDLE_DATA;
+
 public class BookmarksAllSubscriptionPageFragment extends Fragment
 {
-  private static final String BUNDLE_INDEX = "index";
-
   @Nullable
   @Override
   public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
                            @Nullable Bundle savedInstanceState)
   {
-    int index = Objects.requireNonNull(getArguments()).getInt(BUNDLE_INDEX);
-    BookmarksAllSubscriptionPage page = BookmarksAllSubscriptionPage.values()[index];
+    BookmarksAllSubscriptionPageData data = Objects.requireNonNull(getArguments()).getParcelable(BUNDLE_DATA);
+    BookmarksAllSubscriptionPage page = data.getPage();
     FragmentBookmarksAllSubscriptionBinding binding = makeBinding(inflater, container);
     binding.setPage(page);
     binding.description.setText(Html.fromHtml(getString(page.getDescriptionId())));
@@ -40,11 +40,11 @@ public class BookmarksAllSubscriptionPageFragment extends Fragment
   }
 
   @NonNull
-  static Fragment newInstance(int index)
+  static Fragment newInstance(BookmarksAllSubscriptionPageData data)
   {
     BookmarksAllSubscriptionPageFragment fragment = new BookmarksAllSubscriptionPageFragment();
     Bundle args = new Bundle();
-    args.putInt(BUNDLE_INDEX, index);
+    args.putParcelable(BUNDLE_DATA, data);
     fragment.setArguments(args);
     return fragment;
   }

--- a/android/src/com/mapswithme/maps/widget/ParallaxBackgroundPageListener.java
+++ b/android/src/com/mapswithme/maps/widget/ParallaxBackgroundPageListener.java
@@ -17,7 +17,7 @@ public class ParallaxBackgroundPageListener implements ViewPager.OnPageChangeLis
 {
   private static final float ALPHA_TRANSPARENT = 0;
   private static final float ALPHA_OPAQUE = 1;
-  private static final Float INVALID_OFFSET = -1f;
+  private static final float INVALID_OFFSET = -1f;
   @NonNull
   private final List<BookmarksAllSubscriptionPageData> mItems;
   @NonNull


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-15207
ParallaxBackgroundPageLiatener пришлось переписать полностью, тк ранее он работал с хардкодными imageView из лэйаута. Суть фикса заключается в следующих моментах:
* Вместо пробрасывая индекса страницы в качестве аргумента теперь надо пробросить список скринов из енама BookmarksAllSubscriptionPage в нужном порядке, которые необходимо отобразить во вьюпейджере. (см BookmarksAllSubscriptionActivity addBookmarkSubscriptionExtra метод)
* Вместо 2 разных массивов для текста на экране и картинок теперь генерируется единый объект, содержащий в себе и текст, и соотв. картинку, что позволяет избежать рассинхронизации текста и картинки (см метод makeItems в BookmarksAllSubscriptionFragment)
* Вместо работы с 4 хардкодными imageView в листенере вьюпейджера теперь используется 2 imageView динамически. 

Таким образом, можно организовать страницы в любом порядке, исчезает ограничение на количество элементов и упрощается добавление новых. 

Открытый вопрос: Для этого экрана есть Лэндскейп вариант, но у Активити выставлен флаг portrait, надо ли эти изменения поддержать и в Лэндскейп варианте?

P.S. Есть гипотеза, если добавить 9-patch для картинок, то их размер станет меньше и для работы с ними будет использоваться меньше ресурсов, мб попросить дизайн команду нарисовать такую картинку и проверить?

**UPD**
Добавлен коммит для задачи https://jira.mail.ru/browse/MAPSME-15236