### PR TITLE
[pybindings] pykmllib fix

### DIFF
--- a/kml/pykmlib/bindings.cpp
+++ b/kml/pykmlib/bindings.cpp
@@ -795,6 +795,12 @@ BOOST_PYTHON_MODULE(pykmlib)
     .def("set_list", &VectorAdapter<std::string>::Set)
     .def("__str__", &VectorAdapter<std::string>::ToString);
 
+  class_<std::vector<uint64_t>>("Uint64List")
+    .def(vector_indexing_suite<std::vector<uint64_t>>())
+    .def("get_list", &VectorAdapter<uint64_t>::Get)
+    .def("set_list", &VectorAdapter<uint64_t>::Set)
+    .def("__str__", &VectorAdapter<uint64_t>::ToString);
+
   class_<std::vector<uint32_t>>("Uint32List")
     .def(vector_indexing_suite<std::vector<uint32_t>>())
     .def("get_list", &VectorAdapter<uint32_t>::Get)

--- a/kml/pykmlib/bindings_test.py
+++ b/kml/pykmlib/bindings_test.py
@@ -60,6 +60,7 @@ class PyKmlibAdsTest(unittest.TestCase):
         bookmark.nearest_toponym = '12345'
         bookmark.properties.set_dict({'bm_property1':'value1', 'bm_property2':'value2'})
         bookmark.bound_tracks.set_list([0])
+        bookmark.compilations.set_list([1, 2, 3])
 
         layer1 = pykmlib.TrackLayer()
         layer1.line_width = 6.0


### PR DESCRIPTION
Fix for
TypeError: No Python class registered for C++ class std::__1::vector<unsigned long long, std::__1::allocator<unsigned long long> >