### PR TITLE
[DNM][routing] Two threads bidirectional A*.

### DIFF
--- a/coding/file_reader.hpp
+++ b/coding/file_reader.hpp
@@ -10,7 +10,7 @@
 #include <string>
 
 // FileReader, cheap to copy, not thread safe.
-// It is assumed that file is not modified during FireReader lifetime,
+// It is assumed that file is not modified during FileReader lifetime,
 // because of caching and assumption that Size() is constant.
 class FileReader : public ModelReader
 {

--- a/generator/generator_tests/altitude_test.cpp
+++ b/generator/generator_tests/altitude_test.cpp
@@ -134,13 +134,13 @@ void TestAltitudes(DataSource const & dataSource, MwmSet::MwmId const & mwmId,
                    std::string const & mwmPath, bool hasAltitudeExpected,
                    AltitudeGetter & expectedAltitudes)
 {
-  AltitudeLoader loader(dataSource, mwmId);
+  AltitudeLoader loader(dataSource, mwmId, false /* twoThreadsReady */);
   TEST_EQUAL(loader.HasAltitudes(), hasAltitudeExpected, ());
 
   auto processor = [&expectedAltitudes, &loader](FeatureType & f, uint32_t const & id) {
     f.ParseGeometry(FeatureType::BEST_GEOMETRY);
     size_t const pointsCount = f.GetPointsCount();
-    geometry::Altitudes const altitudes = loader.GetAltitudes(id, pointsCount);
+    geometry::Altitudes const altitudes = loader.GetAltitudes(id, pointsCount, true /* isOutgoing */);
 
     if (!routing::IsRoad(feature::TypesHolder(f)))
     {

--- a/generator/generator_tests_support/routing_helpers.cpp
+++ b/generator/generator_tests_support/routing_helpers.cpp
@@ -98,7 +98,7 @@ std::unique_ptr<IndexGraph> BuildIndexGraph(std::unique_ptr<TestGeometryLoader> 
                                             std::vector<Joint> const & joints)
 {
   auto graph = std::make_unique<IndexGraph>(std::make_shared<Geometry>(std::move(geometryLoader)),
-                                       estimator);
+                                            estimator);
   graph->Import(joints);
   return graph;
 }

--- a/generator/generator_tests_support/routing_helpers.cpp
+++ b/generator/generator_tests_support/routing_helpers.cpp
@@ -46,8 +46,9 @@ void ReEncodeOsmIdsToFeatureIdsMapping(std::string const & mappingContent, std::
 
 namespace routing
 {
-void TestGeometryLoader::Load(uint32_t featureId, RoadGeometry & road)
+void TestGeometryLoader::Load(uint32_t featureId, RoadGeometry & road, bool isOutgoing)
 {
+  CHECK(isOutgoing, ("TestGeometryLoader() is not ready for two threads feature parsing."));
   auto const it = m_roads.find(featureId);
   if (it == m_roads.cend())
     return;

--- a/generator/generator_tests_support/routing_helpers.hpp
+++ b/generator/generator_tests_support/routing_helpers.hpp
@@ -31,7 +31,7 @@ class TestGeometryLoader : public GeometryLoader
 {
 public:
   // GeometryLoader overrides:
-  void Load(uint32_t featureId, routing::RoadGeometry & road) override;
+  void Load(uint32_t featureId, routing::RoadGeometry & road, bool isOutgoing) override;
 
   void AddRoad(uint32_t featureId, bool oneWay, float speed,
                routing::RoadGeometry::Points const & points);

--- a/generator/restriction_collector.cpp
+++ b/generator/restriction_collector.cpp
@@ -129,8 +129,10 @@ bool RestrictionCollector::ParseRestrictions(std::string const & path)
 Joint::Id RestrictionCollector::GetFirstCommonJoint(uint32_t firstFeatureId,
                                                     uint32_t secondFeatureId) const
 {
-  uint32_t const firstLen = m_indexGraph->GetGeometry().GetRoad(firstFeatureId).GetPointsCount();
-  uint32_t const secondLen = m_indexGraph->GetGeometry().GetRoad(secondFeatureId).GetPointsCount();
+  uint32_t const firstLen =
+      m_indexGraph->GetGeometry().GetRoad(firstFeatureId, true /* isOutgoing */).GetPointsCount();
+  uint32_t const secondLen =
+      m_indexGraph->GetGeometry().GetRoad(secondFeatureId, true /* isOutgoing */).GetPointsCount();
 
   auto const firstRoad = m_indexGraph->GetRoad(firstFeatureId);
   auto const secondRoad = m_indexGraph->GetRoad(secondFeatureId);
@@ -155,7 +157,7 @@ bool RestrictionCollector::FeatureHasPointWithCoords(uint32_t featureId,
                                                      m2::PointD const & coords) const
 {
   CHECK(m_indexGraph, ());
-  auto const & roadGeometry = m_indexGraph->GetGeometry().GetRoad(featureId);
+  auto const & roadGeometry = m_indexGraph->GetGeometry().GetRoad(featureId, true /* isOutgoing */);
   uint32_t const pointsCount = roadGeometry.GetPointsCount();
   for (uint32_t i = 0; i < pointsCount; ++i)
   {
@@ -245,7 +247,7 @@ bool RestrictionCollector::CheckAndProcessUTurn(Restriction::Type & restrictionT
 
     uint32_t & featureId = featureIds.back();
 
-    auto const & road = m_indexGraph->GetGeometry().GetRoad(featureId);
+    auto const & road = m_indexGraph->GetGeometry().GetRoad(featureId, true /* isOutgoing */);
     // Can not do UTurn from feature to the same feature if it is one way.
     if (road.IsOneWay())
       return false;

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -173,7 +173,7 @@ public:
   routing::Segment GetFinishSegment() const { return {}; }
   bool ConvertToReal(routing::Segment const & /* segment */) const { return false; }
   routing::RouteWeight HeuristicCostEstimate(routing::Segment const & /* from */,
-                                             ms::LatLon const & /* to */)
+                                             ms::LatLon const & /* to */, bool /* isOutgoing */)
   {
     CHECK(false, ("This method exists only for compatibility with IndexGraphStarterJoints"));
     return routing::GetAStarWeightZero<routing::RouteWeight>();
@@ -202,9 +202,9 @@ public:
   routing::RouteWeight GetAStarWeightEpsilon() { return routing::RouteWeight(0.0); }
   // @}
 
-  ms::LatLon const & GetPoint(routing::Segment const & s, bool forward)
+  ms::LatLon const & GetPoint(routing::Segment const & s, bool forward, bool isOutgoing)
   {
-    return m_graph.GetPoint(s, forward);
+    return m_graph.GetPoint(s, forward, isOutgoing);
   }
 
   void GetEdgesList(routing::Segment const & child, bool isOutgoing,
@@ -256,7 +256,8 @@ public:
   {
   }
 
-  Weight HeuristicCostEstimate(Vertex const & /* from */, Vertex const & /* to */) override
+  Weight HeuristicCostEstimate(Vertex const & /* from */, Vertex const & /* to */,
+                               bool /* isOutgoing */) override
   {
     return routing::GetAStarWeightZero<Weight>();
   }

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -223,14 +223,14 @@ public:
                                *m_AStarParents);
   }
 
-  bool IsJoint(routing::Segment const & segment, bool fromStart) const
+  bool IsJoint(routing::Segment const & segment, bool fromStart, bool isOutgoing) const
   {
-    return IsJointOrEnd(segment, fromStart);
+    return IsJointOrEnd(segment, fromStart, isOutgoing);
   }
 
-  bool IsJointOrEnd(routing::Segment const & segment, bool fromStart) const
+  bool IsJointOrEnd(routing::Segment const & segment, bool fromStart, bool isOutgoing) const
   {
-    return m_graph.IsJointOrEnd(segment, fromStart);
+    return m_graph.IsJointOrEnd(segment, fromStart, isOutgoing);
   }
 
   template <typename Vertex>

--- a/generator/routing_index_generator.cpp
+++ b/generator/routing_index_generator.cpp
@@ -200,6 +200,7 @@ public:
   }
 
   routing::RouteWeight GetAStarWeightEpsilon() { return routing::RouteWeight(0.0); }
+  bool IsTwoThreadsReady() const { return false; }
   // @}
 
   ms::LatLon const & GetPoint(routing::Segment const & s, bool forward, bool isOutgoing)

--- a/indexer/altitude_loader.hpp
+++ b/indexer/altitude_loader.hpp
@@ -25,27 +25,43 @@ namespace feature
 class AltitudeLoader
 {
 public:
-  AltitudeLoader(DataSource const & dataSource, MwmSet::MwmId const & mwmId);
-
-  /// \returns altitude of feature with |featureId|. All items of the returned vector are valid
-  /// or the returned vector is empty.
-  geometry::Altitudes const & GetAltitudes(uint32_t featureId, size_t pointCount);
+  AltitudeLoader(DataSource const & dataSource, MwmSet::MwmId const & mwmId,
+                 bool twoThreadsReady);
 
   bool HasAltitudes() const;
 
-  void ClearCache() { m_cache.clear(); }
+  /// \returns altitude of feature with |featureId|. All items of the returned vector are valid
+  /// or the returned vector is empty.
+  geometry::Altitudes const & GetAltitudes(uint32_t featureId, size_t pointCount, bool isOutgoing);
+
+  bool IsTwoThreadsReady() const { return m_handleBwd != nullptr; }
+
+  void ClearCache(bool isOutgoing) { isOutgoing ? m_cache.clear() : m_cacheBwd.clear(); }
 
 private:
+  geometry::Altitudes const & GetAltitudes(
+      uint32_t featureId, size_t pointCount, std::unique_ptr<FilesContainerR::TReader> & reader,
+      std::map<uint32_t, geometry::Altitudes> & cache) const;
+
   std::unique_ptr<CopiedMemoryRegion> m_altitudeAvailabilityRegion;
   std::unique_ptr<CopiedMemoryRegion> m_featureTableRegion;
 
   succinct::rs_bit_vector m_altitudeAvailability;
   succinct::elias_fano m_featureTable;
 
+  // Note. If |twoThreadsReady| parameter of constructor is true method GetAltitudes() may be called
+  // from two different threads. In that case all calls of GetAltitudes() with |isOutgoing| == true
+  // should be done from one thread and from another one of |isOutgoing| == true.
+  // To call GetAltitudes() from two threads without locks it's necessary to have
+  // two caches for reading from disk (in m_handle/m_reader and m_handleBwd/m_readerBwd)
+  // and two caches for keeping read altitudes (m_cache and m_cacheBwd).
   std::unique_ptr<FilesContainerR::TReader> m_reader;
+  std::unique_ptr<FilesContainerR::TReader> m_readerBwd;
   std::map<uint32_t, geometry::Altitudes> m_cache;
+  std::map<uint32_t, geometry::Altitudes> m_cacheBwd;
   AltitudeHeader m_header;
   std::string m_countryFileName;
   MwmSet::MwmHandle m_handle;
+  std::unique_ptr<MwmSet::MwmHandle> m_handleBwd;
 };
 }  // namespace feature

--- a/routing/async_router.cpp
+++ b/routing/async_router.cpp
@@ -398,7 +398,7 @@ void AsyncRouter::CalculateRoute()
       absentFetcher->GenerateRequest(checkpoints);
 
     // Run basic request.
-    code = router->CalculateRoute(checkpoints, startDirection, adjustToPrevRoute,
+    code = router->CalculateRoute(checkpoints, startDirection, true /* useTwoThreads */, adjustToPrevRoute,
                                   delegateProxy->GetDelegate(), *route);
     router->SetGuides({});
     elapsedSec = timer.ElapsedSeconds(); // routing time

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -28,13 +28,13 @@ namespace astar
 template <typename Vertex>
 struct DefaultVisitor
 {
-  void operator()(Vertex const & /* from */, Vertex const & /* to */) const {};
+  void operator()(Vertex const & /* from */, Vertex const & /* to */, bool /* isOutgoing */) const {};
 };
 
 template <typename Weight>
 struct DefaultLengthChecker
 {
-  bool operator()(Weight const & /* weight */) const { return true; }
+  bool operator()(Weight const & /* weight */, bool /* isOutgoing */) const { return true; }
 };
 }  // namespace astar
 
@@ -540,7 +540,7 @@ AStarAlgorithm<Vertex, Edge, Weight>::FindPath(P & params, RoutingResult<Vertex,
     result.m_distance =
         reducedToFullLength(startVertex, finalVertex, context.GetDistance(finalVertex));
 
-    if (!params.m_checkLengthCallback(result.m_distance), true /* forward */)
+    if (!params.m_checkLengthCallback(result.m_distance, true /* forward */))
       resultCode = Result::NoPath;
   }
 

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -220,7 +220,6 @@ public:
   /// It's worth using one thread version if there's only one core available.
   /// if |params.m_graph.IsTwoThreadsReady()| returns true two thread version is used.
   /// If the decision is made to use two thread version it should be taken into account:
-  /// If the decision is made to use two thread version it should be taken into account:
   /// - |isOutgoing| flag in each method specified which thread calls the method
   /// - All callbacks which are called from |wave| lambda such as |params.m_onVisitedVertexCallback|
   ///   or |params.m_checkLengthCallback| should be ready for calling from two threads

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -222,10 +222,9 @@ public:
   /// If the decision is made to use two thread version it should be taken into account:
   /// - |isOutgoing| flag in each method specified which thread calls the method
   /// - All callbacks which are called from |wave| lambda such as |params.m_onVisitedVertexCallback|
-  ///   or |params.m_checkLengthCallback| should be ready for calling from two threads
+  ///   or |params.m_checkLengthCallback| should be ready for calling from two threads.
   template <typename P>
   Result FindPathBidirectional(P & params, RoutingResult<Vertex, Weight> & result) const;
-
 
   // Adjust route to the previous one.
   // Expects |params.m_checkLengthCallback| to check wave propagation limit.
@@ -630,6 +629,8 @@ AStarAlgorithm<Vertex, Edge, Weight>::FindPathBidirectional(P & params,
   auto const & startVertex = params.m_startVertex;
 
   auto const useTwoThreads = graph.IsTwoThreadsReady();
+  LOG(LINFO,
+      (useTwoThreads ? "Bidirectional A* in two threads." : "Bidirectional A* in one thread."));
   std::optional<std::mutex> mtx;
 
   BidirectionalStepContext forward(mtx, true /* forward */, startVertex, finalVertex, graph);

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -399,6 +399,8 @@ private:
 
     Vertex const & GetEndVertex() const { return forward ? finalVertex : startVertex; }
 
+    bool IsNextVertex() const {return !queue.empty() || stateV; }
+
     bool IsTwoThreadsReady() const { return mtx.has_value(); }
 
     std::optional<std::mutex> & mtx;
@@ -765,9 +767,7 @@ AStarAlgorithm<Vertex, Edge, Weight>::FindPathBidirectional(P & params,
   PeriodicPollCancellable periodicCancellable(params.m_cancellable);
 
   // One thread step.
-  // While both of contextses are ready to continue. It means
-  // each one has to have items in queue or some edges have come for two thread step.
-  while (!(cur->queue.empty() && !cur->stateV) && !(nxt->queue.empty() && !nxt->stateV))
+  while (cur->IsNextVertex() && nxt->IsNextVertex())
   {
 //    LOG(LINFO, ("---------cur is", cur->forward ? "forward" : "backward", "cur queue size:", cur->queue.size(), "next queue size:", nxt->queue.size()));
     ++steps;

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -9,11 +9,11 @@
 #include "base/cancellable.hpp"
 #include "base/logging.hpp"
 #include "base/optional_lock_guard.hpp"
+#include "base/thread.hpp"
 
 #include <algorithm>
 #include <atomic>
 #include <functional>
-#include <future>
 #include <iostream>
 #include <map>
 #include <mutex>
@@ -726,10 +726,10 @@ AStarAlgorithm<Vertex, Edge, Weight>::FindPathBidirectional(P & params,
     // Starting two wave in two threads.
     {
       base::ScopedTimerWithLog timer("Wave");
-      auto backwardWave = std::async(std::launch::async, wave, std::ref(backward),
-                                     std::ref(forward), std::ref(shouldExit));
+      threads::SimpleThread backwardWave(wave, std::ref(backward),
+                                         std::ref(forward), std::ref(shouldExit));
       wave(forward, backward, shouldExit);
-      backwardWave.get();
+      backwardWave.join();
     }
     LOG(LINFO, ("-------Two thread part of FindPath-------Finished-----------------"));
     ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -315,7 +315,6 @@ private:
     // particular routes when debugging turned out to be easier.
     Weight ConsistentHeuristic(Vertex const & v) const
     {
-      // TODO. The last parameter may be false in case of two thread routing.
       bool const isTwoThreads = IsTwoThreadsReady();
       auto const piF = graph.HeuristicCostEstimate(v, finalVertex, isTwoThreads ?  forward : true);
       auto const piR = graph.HeuristicCostEstimate(v, startVertex, isTwoThreads ?  forward : true);

--- a/routing/base/astar_algorithm.hpp
+++ b/routing/base/astar_algorithm.hpp
@@ -597,6 +597,9 @@ AStarAlgorithm<Vertex, Edge, Weight>::FindPathBidirectional(bool useTwoThreads, 
   {
     mtx.emplace();
     //////////////////////////////////////////////////////////////////////////////////////////////////
+    // @TODO The multithreading code below in wave lambda is used more or less the same line
+    // as one thread bidirectional version. Consider put in some functions and call them for
+    // one thread and two thread versions.
     auto wave = [&epsilon](BidirectionalStepContext & context, std::atomic<bool> & queueIsEmpty,
                            BidirectionalStepContext & oppositeContext,
                            std::atomic<bool> & oppositeQueueIsEmpty) {
@@ -614,6 +617,7 @@ AStarAlgorithm<Vertex, Edge, Weight>::FindPathBidirectional(bool useTwoThreads, 
         if (context.ExistsStateWithBetterDistance(stateV))
           continue;
 
+        // @TODO This call should be synchronized in two thread case.
         //      params.m_onVisitedVertexCallback(stateV.vertex, context.forward ? context.finalVertex : context.startVertex);
         context.GetAdjacencyList(stateV, adj);
         auto const & pV = stateV.heuristic;
@@ -634,6 +638,7 @@ AStarAlgorithm<Vertex, Edge, Weight>::FindPathBidirectional(bool useTwoThreads, 
 
           stateW.distance = stateV.distance + std::max(reducedWeight, kZeroDistance);
 
+          // @TODO This call should be synchronized in two thread case.
           //        auto const fullLength = weight + stateV.distance + context.pS - pV;
 
           //        if (!params.m_checkLengthCallback(fullLength))
@@ -663,6 +668,7 @@ AStarAlgorithm<Vertex, Edge, Weight>::FindPathBidirectional(bool useTwoThreads, 
       LOG(LINFO, ("----FindPath------wave end (empty)---------------------------",
                   context.forward ? "forward" : "backward"));
     };
+    CHECK(!mtx.has_value(), ("Mutex should be destroyed."));
 
     std::atomic<bool> fwdIsEmpty;
     std::atomic<bool> bwdIsEmpty;

--- a/routing/base/astar_graph.hpp
+++ b/routing/base/astar_graph.hpp
@@ -20,7 +20,7 @@ public:
 
   using Parents = ska::bytell_hash_map<Vertex, Vertex>;
 
-  virtual Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to) = 0;
+  virtual Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to, bool isOutgoing) = 0;
 
   virtual void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
                                     std::vector<Edge> & edges) = 0;

--- a/routing/base/astar_graph.hpp
+++ b/routing/base/astar_graph.hpp
@@ -20,6 +20,12 @@ public:
 
   using Parents = ska::bytell_hash_map<Vertex, Vertex>;
 
+  constexpr AStarGraph(bool multithreadingReady = false)
+    : m_multithreadingReady(multithreadingReady)
+  {
+  }
+  virtual ~AStarGraph() = default;
+
   virtual Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to, bool isOutgoing) = 0;
 
   virtual void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
@@ -34,7 +40,10 @@ public:
 
   virtual Weight GetAStarWeightEpsilon();
 
-  virtual ~AStarGraph() = default;
+  constexpr bool GetMultithreadingReady() const { return m_multithreadingReady;}
+
+private:
+  bool const m_multithreadingReady;
 };
 
 template <typename VertexType, typename EdgeType, typename WeightType>

--- a/routing/base/astar_graph.hpp
+++ b/routing/base/astar_graph.hpp
@@ -20,10 +20,7 @@ public:
 
   using Parents = ska::bytell_hash_map<Vertex, Vertex>;
 
-  constexpr AStarGraph(bool multithreadingReady = false)
-    : m_twoThreadsReady(multithreadingReady)
-  {
-  }
+  constexpr AStarGraph() {}
   virtual ~AStarGraph() = default;
 
   virtual Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to, bool isOutgoing) = 0;
@@ -40,10 +37,7 @@ public:
 
   virtual Weight GetAStarWeightEpsilon();
 
-  constexpr bool IsTwoThreadsReady() const { return m_twoThreadsReady;}
-
-private:
-  bool const m_twoThreadsReady;
+  virtual bool IsTwoThreadsReady() const { return false; }
 };
 
 template <typename VertexType, typename EdgeType, typename WeightType>

--- a/routing/base/astar_graph.hpp
+++ b/routing/base/astar_graph.hpp
@@ -21,7 +21,7 @@ public:
   using Parents = ska::bytell_hash_map<Vertex, Vertex>;
 
   constexpr AStarGraph(bool multithreadingReady = false)
-    : m_multithreadingReady(multithreadingReady)
+    : m_twoThreadsReady(multithreadingReady)
   {
   }
   virtual ~AStarGraph() = default;
@@ -40,10 +40,10 @@ public:
 
   virtual Weight GetAStarWeightEpsilon();
 
-  constexpr bool GetMultithreadingReady() const { return m_multithreadingReady;}
+  constexpr bool IsTwoThreadsReady() const { return m_twoThreadsReady;}
 
 private:
-  bool const m_multithreadingReady;
+  bool const m_twoThreadsReady;
 };
 
 template <typename VertexType, typename EdgeType, typename WeightType>

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -88,6 +88,7 @@ void CrossMwmGraph::DeserializeTransitTransitions(vector<NumMwmId> const & mwmId
 
 void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment> & twins)
 {
+  // @TODO. This method may be called from two threads. It should be ready for it.
   ASSERT(IsTransition(s, isOutgoing),
         ("The segment", s, "is not a transition segment for isOutgoing ==", isOutgoing));
   // Note. There's an extremely rare case when a segment is ingoing and outgoing at the same time.

--- a/routing/cross_mwm_graph.cpp
+++ b/routing/cross_mwm_graph.cpp
@@ -88,7 +88,6 @@ void CrossMwmGraph::DeserializeTransitTransitions(vector<NumMwmId> const & mwmId
 
 void CrossMwmGraph::GetTwins(Segment const & s, bool isOutgoing, vector<Segment> & twins)
 {
-  // @TODO. This method may be called from two threads. It should be ready for it.
   ASSERT(IsTransition(s, isOutgoing),
         ("The segment", s, "is not a transition segment for isOutgoing ==", isOutgoing));
   // Note. There's an extremely rare case when a segment is ingoing and outgoing at the same time.

--- a/routing/cross_mwm_index_graph.hpp
+++ b/routing/cross_mwm_index_graph.hpp
@@ -276,10 +276,12 @@ private:
     ReaderSourceFile src(reader);
     auto it = m_connectors.find(numMwmId);
     if (it == m_connectors.end())
+    {
       it = m_connectors
                .emplace(numMwmId, CrossMwmConnector<CrossMwmId>(
                                       numMwmId, connector::GetFeaturesOffset<CrossMwmId>()))
                .first;
+    }
 
     fn(m_vehicleType, it->second, src);
     return it->second;

--- a/routing/fake_ending.cpp
+++ b/routing/fake_ending.cpp
@@ -61,9 +61,9 @@ FakeEnding MakeFakeEnding(vector<Segment> const & segments, m2::PointD const & p
   {
     auto const & segment = segments[i];
 
-    bool const oneWay = graph.IsOneWay(segment.GetMwmId(), segment.GetFeatureId());
-    auto const & frontJunction = graph.GetJunction(segment, true /* front */);
-    auto const & backJunction = graph.GetJunction(segment, false /* front */);
+    bool const oneWay = graph.IsOneWay(segment.GetMwmId(), segment.GetFeatureId(), true /* isOutgoing */);
+    auto const & frontJunction = graph.GetJunction(segment, true /* front */, true /* isOutgoing */);
+    auto const & backJunction = graph.GetJunction(segment, false /* front */, true /* isOutgoing */);
     auto const & projectedJunction = CalcProjectionToSegment(backJunction, frontJunction, point);
 
     ending.m_projections.emplace_back(segment, oneWay, frontJunction, backJunction,
@@ -79,7 +79,7 @@ FakeEnding MakeFakeEnding(vector<Segment> const & segments, m2::PointD const & p
 
 FakeEnding MakeFakeEnding(Segment const & segment, m2::PointD const & point, IndexGraph & graph)
 {
-  auto const & road = graph.GetGeometry().GetRoad(segment.GetFeatureId());
+  auto const & road = graph.GetGeometry().GetRoad(segment.GetFeatureId(), true /* isOutgoing */);
   bool const oneWay = road.IsOneWay();
   auto const & frontJunction = road.GetJunction(segment.GetPointId(true /* front */));
   auto const & backJunction = road.GetJunction(segment.GetPointId(false /* front */));

--- a/routing/features_road_graph.cpp
+++ b/routing/features_road_graph.cpp
@@ -41,7 +41,11 @@ FeaturesRoadGraph::Value::Value(DataSource const & dataSource, MwmSet::MwmHandle
   if (!m_mwmHandle.IsAlive())
     return;
 
-  m_altitudeLoader = make_unique<feature::AltitudeLoader>(dataSource, m_mwmHandle.GetId());
+  // Note. FeaturesRoadGraph is always used now from one thread. But if to find the best
+  // edge for start and finish from two threads the instance of FeaturesRoadGraph
+  // should have two thread support.
+  m_altitudeLoader = make_unique<feature::AltitudeLoader>(dataSource, m_mwmHandle.GetId(),
+                                                          false /* twoThreadsReady */);
 }
 
 FeaturesRoadGraph::CrossCountryVehicleModel::CrossCountryVehicleModel(
@@ -311,7 +315,8 @@ void FeaturesRoadGraph::ExtractRoadInfo(FeatureID const & featureId, FeatureType
   geometry::Altitudes altitudes;
   if (value.m_altitudeLoader)
   {
-    altitudes = value.m_altitudeLoader->GetAltitudes(featureId.m_index, ft.GetPointsCount());
+    altitudes = value.m_altitudeLoader->GetAltitudes(featureId.m_index, ft.GetPointsCount(),
+                                                     true /* isOutgoing */);
   }
   else
   {

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -262,7 +262,7 @@ Geometry::Geometry(unique_ptr<GeometryLoader> loader)
   CHECK(m_loader, ());
 }
 
-RoadGeometry const & Geometry::GetRoad(uint32_t featureId)
+RoadGeometry const & Geometry::GetRoad(uint32_t featureId, bool isOutgoing)
 {
   ASSERT(m_featureIdToRoad, ());
   ASSERT(m_loader, ());

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -60,8 +60,8 @@ class GeometryLoaderImpl final : public GeometryLoader
 {
 public:
   GeometryLoaderImpl(DataSource const & dataSource, MwmSet::MwmHandle const & handle,
-                     shared_ptr<VehicleModelInterface> vehicleModel,
-                     AttrLoader attrLoader, bool loadAltitudes);
+                     shared_ptr<VehicleModelInterface> vehicleModel, AttrLoader attrLoader,
+                     bool loadAltitudes);
 
   // GeometryLoader overrides:
   void Load(uint32_t featureId, RoadGeometry & road) override;
@@ -253,8 +253,8 @@ double RoadGeometry::GetRoadLengthM() const
 }
 
 // Geometry ----------------------------------------------------------------------------------------
-Geometry::Geometry(unique_ptr<GeometryLoader> loader)
-    : m_loader(move(loader))
+Geometry::Geometry(std::unique_ptr<GeometryLoader> loader, bool twoThreadsReady)
+  : m_loader(move(loader))
     , m_featureIdToRoad(make_unique<RoutingFifoCache>(
         kRoadsCacheSize,
         [this](uint32_t featureId, RoadGeometry & road) { m_loader->Load(featureId, road); }))
@@ -271,11 +271,10 @@ RoadGeometry const & Geometry::GetRoad(uint32_t featureId, bool isOutgoing)
 }
 
 // static
-unique_ptr<GeometryLoader> GeometryLoader::Create(DataSource const & dataSource,
-                                                  MwmSet::MwmHandle const & handle,
-                                                  shared_ptr<VehicleModelInterface> vehicleModel,
-                                                  AttrLoader && attrLoader,
-                                                  bool loadAltitudes)
+unique_ptr<GeometryLoader> GeometryLoader::Create(
+    DataSource const & dataSource, MwmSet::MwmHandle const & handle,
+    std::shared_ptr<VehicleModelInterface> vehicleModel, AttrLoader && attrLoader,
+    bool loadAltitudes)
 {
   CHECK(handle.IsAlive(), ());
   return make_unique<GeometryLoaderImpl>(dataSource, handle, vehicleModel, move(attrLoader),

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -91,7 +91,7 @@ GeometryLoaderImpl::GeometryLoaderImpl(DataSource const & dataSource,
   , m_guardBwd(twoThreadsReady ? make_unique<FeaturesLoaderGuard>(dataSource, handle.GetId())
                                : nullptr)
   , m_country(handle.GetInfo()->GetCountryName())
-  , m_altitudeLoader(dataSource, handle.GetId())
+  , m_altitudeLoader(dataSource, handle.GetId(), twoThreadsReady)
   , m_loadAltitudes(loadAltitudes)
 {
   CHECK(handle.IsAlive(), ());
@@ -118,13 +118,13 @@ void GeometryLoaderImpl::Load(uint32_t featureId, RoadGeometry & road, bool isOu
   feature->ParseGeometry(FeatureType::BEST_GEOMETRY);
 
   geometry::Altitudes const * altitudes = nullptr;
-  // TODO Altitude should be refactored to be able to be accessible from two threads.
-//  if (m_loadAltitudes)
-//    altitudes = &(m_altitudeLoader.GetAltitudes(featureId, feature->GetPointsCount()));
+
+  if (m_loadAltitudes)
+    altitudes = &(m_altitudeLoader.GetAltitudes(featureId, feature->GetPointsCount(), isOutgoing));
 
   road.Load(*m_vehicleModel, *feature, altitudes, m_attrLoader.m_cityRoads->IsCityRoad(featureId),
             m_attrLoader.m_maxspeeds->GetMaxspeed(featureId));
-//  m_altitudeLoader.ClearCache();
+  m_altitudeLoader.ClearCache(isOutgoing);
 }
 
 // FileGeometryLoader ------------------------------------------------------------------------------

--- a/routing/geometry.cpp
+++ b/routing/geometry.cpp
@@ -278,18 +278,6 @@ Geometry::Geometry(std::unique_ptr<GeometryLoader> loader, bool twoThreadsReady)
                                 true /* isOutgoing */))
   , m_featureIdToRoadBwd(
         twoThreadsReady ? MakeCache(kRoadsCacheSizeTwoCaches, false /* isOutgoing */) : nullptr)
-//  , m_featureIdToRoad(
-//        make_unique<RoutingFifoCache>(twoThreadsReady ? kRoadsCacheSizeTwoCaches : kRoadsCacheSize,
-//                                      [this](uint32_t featureId, RoadGeometry & road) {
-//                                        m_loader->Load(featureId, road, true /* isOutgoing */);
-//                                      }))
-//  , m_featureIdToRoadBwd(twoThreadsReady
-//                             ? make_unique<RoutingFifoCache>(
-//                                   kRoadsCacheSizeTwoCaches,
-//                                   [this](uint32_t featureId, RoadGeometry & road) {
-//                                     m_loader->Load(featureId, road, false /* isOutgoing */);
-//                                   })
-//                             : nullptr)
 {
   CHECK(m_loader, ());
 }

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -139,13 +139,13 @@ public:
 
   /// \note The reference returned by the method is valid until the next call of GetRoad()
   /// of GetPoint() methods.
-  RoadGeometry const & GetRoad(uint32_t featureId);
+  RoadGeometry const & GetRoad(uint32_t featureId, bool isOutgoing);
 
   /// \note The reference returned by the method is valid until the next call of GetRoad()
   /// of GetPoint() methods.
-  ms::LatLon const & GetPoint(RoadPoint const & rp)
+  ms::LatLon const & GetPoint(RoadPoint const & rp, bool isOutgoing)
   {
-    return GetRoad(rp.GetFeatureId()).GetPoint(rp.GetPointId());
+    return GetRoad(rp.GetFeatureId(), isOutgoing).GetPoint(rp.GetPointId());
   }
 
 private:

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -149,10 +149,11 @@ public:
   }
 
 private:
-  bool IsTwoThreadsReady() const { return m_featureIdToRoadBwd != nullptr; }
-
   using RoutingFifoCache =
       FifoCache<uint32_t, RoadGeometry, ska::bytell_hash_map<uint32_t, RoadGeometry>>;
+
+  bool IsTwoThreadsReady() const { return m_featureIdToRoadBwd != nullptr; }
+  std::unique_ptr<RoutingFifoCache> MakeCache(size_t cacheSize, bool isOutgoing) const;
 
   std::unique_ptr<GeometryLoader> m_loader;
   std::unique_ptr<RoutingFifoCache> m_featureIdToRoad;

--- a/routing/geometry.hpp
+++ b/routing/geometry.hpp
@@ -114,8 +114,7 @@ public:
   static std::unique_ptr<GeometryLoader> Create(DataSource const & dataSource,
                                                 MwmSet::MwmHandle const & handle,
                                                 std::shared_ptr<VehicleModelInterface> vehicleModel,
-                                                AttrLoader && attrLoader,
-                                                bool loadAltitudes);
+                                                AttrLoader && attrLoader, bool loadAltitudes);
 
   /// This is for stand-alone work.
   /// Use in generator_tool and unit tests.
@@ -135,7 +134,7 @@ class Geometry final
 {
 public:
   Geometry() = default;
-  explicit Geometry(std::unique_ptr<GeometryLoader> loader);
+  explicit Geometry(std::unique_ptr<GeometryLoader> loader, bool twoThreadsReady = false);
 
   /// \note The reference returned by the method is valid until the next call of GetRoad()
   /// of GetPoint() methods.

--- a/routing/guides_connections.hpp
+++ b/routing/guides_connections.hpp
@@ -107,6 +107,11 @@ public:
   // Returns fake ending associated with checkpoint by its index |checkpointIdx|.
   FakeEnding GetFakeEnding(size_t checkpointIdx) const;
 
+  void Clear()
+  {
+    m_checkpointsFakeEndings.clear();
+  }
+
 private:
   // Fills |ConnectionToOsm| for checkpoints for its further attachment to the roads graph.
   void AddConnectionToOsm(size_t checkpointIdx, Segment const & real,

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -48,7 +48,7 @@ bool IndexGraph::IsJoint(RoadPoint const & roadPoint) const
   return m_roadIndex.GetJointId(roadPoint) != Joint::kInvalidId;
 }
 
-bool IndexGraph::IsJointOrEnd(Segment const & segment, bool fromStart)
+bool IndexGraph::IsJointOrEnd(Segment const & segment, bool fromStart, bool isOutgoing)
 {
   if (IsJoint(segment.GetRoadPoint(fromStart)))
     return true;

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -320,6 +320,9 @@ void IndexGraph::GetSegmentCandidateForJoint(Segment const & parent, bool isOutg
 /// \param |parentWeights| - see |IndexGraphStarterJoints::GetEdgeList| method about this argument.
 ///                          Shortly - in case of |isOutgoing| == false, method saves here the weights
 ///                                   from parent to firstChildren.
+/// \note Despite the fact the method is not constant it still may be called from two
+/// threads. One should call it with |isOutgoing| == true and another one with
+/// |isOutgoing| == false.
 void IndexGraph::ReconstructJointSegment(astar::VertexData<JointSegment, RouteWeight> const & parentVertexData,
                                          Segment const & parent,
                                          vector<Segment> const & firstChildren,

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -181,6 +181,7 @@ optional<JointEdge> IndexGraph::GetJointEdgeByLastPoint(Segment const & parent,
                                                         Segment const & firstChild, bool isOutgoing,
                                                         uint32_t lastPoint)
 {
+  // @TODO It should be ready for calling form two threads if IsTwoThreadsReady() returns true.
   vector<Segment> const possibleChildren = {firstChild};
   vector<uint32_t> const lastPoints = {lastPoint};
 

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -181,7 +181,6 @@ optional<JointEdge> IndexGraph::GetJointEdgeByLastPoint(Segment const & parent,
                                                         Segment const & firstChild, bool isOutgoing,
                                                         uint32_t lastPoint)
 {
-  // @TODO It should be ready for calling from two threads if IsTwoThreadsReady() returns true.
   vector<Segment> const possibleChildren = {firstChild};
   vector<uint32_t> const lastPoints = {lastPoint};
 

--- a/routing/index_graph.cpp
+++ b/routing/index_graph.cpp
@@ -181,7 +181,7 @@ optional<JointEdge> IndexGraph::GetJointEdgeByLastPoint(Segment const & parent,
                                                         Segment const & firstChild, bool isOutgoing,
                                                         uint32_t lastPoint)
 {
-  // @TODO It should be ready for calling form two threads if IsTwoThreadsReady() returns true.
+  // @TODO It should be ready for calling from two threads if IsTwoThreadsReady() returns true.
   vector<Segment> const possibleChildren = {firstChild};
   vector<uint32_t> const lastPoints = {lastPoint};
 

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -108,7 +108,7 @@ public:
   }
 
   bool IsJoint(RoadPoint const & roadPoint) const;
-  bool IsJointOrEnd(Segment const & segment, bool fromStart);
+  bool IsJointOrEnd(Segment const & segment, bool fromStart, bool isOutgoing);
   void GetLastPointsForJoint(std::vector<Segment> const & children, bool isOutgoing,
                              std::vector<uint32_t> & lastPoints);
 

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -113,9 +113,11 @@ public:
                              std::vector<uint32_t> & lastPoints);
 
   WorldGraphMode GetMode() const;
-  ms::LatLon const & GetPoint(Segment const & segment, bool front)
+  ms::LatLon const & GetPoint(Segment const & segment, bool front, bool isOutgoing)
   {
-    return GetGeometry().GetRoad(segment.GetFeatureId()).GetPoint(segment.GetPointId(front));
+    return GetGeometry()
+        .GetRoad(segment.GetFeatureId(), isOutgoing)
+        .GetPoint(segment.GetPointId(front));
   }
 
   /// \brief Check, that we can go to |currentFeatureId|.
@@ -129,8 +131,8 @@ public:
 
   bool IsUTurnAndRestricted(Segment const & parent, Segment const & child, bool isOutgoing) const;
 
-  RouteWeight CalculateEdgeWeight(EdgeEstimator::Purpose purpose, bool isOutgoing,
-                                  Segment const & from, Segment const & to,
+  RouteWeight CalculateEdgeWeight(EdgeEstimator::Purpose purpose,
+                                  Segment const & from, Segment const & to, bool isOutgoing,
                                   std::optional<RouteWeight const> const & prevWeight = std::nullopt);
 
   template <typename T>
@@ -164,14 +166,14 @@ private:
     bool m_isFerry;
   };
 
-  PenaltyData GetRoadPenaltyData(Segment const & segment);
+  PenaltyData GetRoadPenaltyData(Segment const & segment, bool isOutgoing);
 
   /// \brief Calculates penalties for moving from |u| to |v|.
   /// \param |prevWeight| uses for fetching access:conditional. In fact it is time when user
   /// will be at |u|. This time is based on start time of route building and weight of calculated
   /// path until |u|.
   RouteWeight GetPenalties(EdgeEstimator::Purpose purpose, Segment const & u, Segment const & v,
-                           std::optional<RouteWeight> const & prevWeight);
+                           bool isOutgoing, std::optional<RouteWeight> const & prevWeight);
 
   void GetSegmentCandidateForRoadPoint(RoadPoint const & rp, NumMwmId numMwmId,
                                        bool isOutgoing, std::vector<Segment> & children);

--- a/routing/index_graph.hpp
+++ b/routing/index_graph.hpp
@@ -131,6 +131,9 @@ public:
 
   bool IsUTurnAndRestricted(Segment const & parent, Segment const & child, bool isOutgoing) const;
 
+  /// \note Despite the fact the method is not constant it still may be called from two
+  /// threads. One should call it with |isOutgoing| == true and another one with
+  /// |isOutgoing| == false.
   RouteWeight CalculateEdgeWeight(EdgeEstimator::Purpose purpose,
                                   Segment const & from, Segment const & to, bool isOutgoing,
                                   std::optional<RouteWeight const> const & prevWeight = std::nullopt);

--- a/routing/index_graph_loader.cpp
+++ b/routing/index_graph_loader.cpp
@@ -209,8 +209,9 @@ IndexGraphLoaderImpl::GraphAttrs & IndexGraphLoaderImpl::CreateGeometry(NumMwmId
 
   base::OptionalLockGuard guard(m_graphsMtx);
   auto & graph = m_graphs[numMwmId];
-  graph.m_geometry = make_shared<Geometry>(GeometryLoader::Create(
-      m_dataSource, handle, vehicleModel, AttrLoader(m_dataSource, handle), m_loadAltitudes));
+  graph.m_geometry = make_shared<Geometry>(
+      GeometryLoader::Create(m_dataSource, handle, vehicleModel, AttrLoader(m_dataSource, handle),
+                             m_loadAltitudes), IsTwoThreadsReady());
   return graph;
 }
 

--- a/routing/index_graph_loader.cpp
+++ b/routing/index_graph_loader.cpp
@@ -34,7 +34,7 @@ using namespace std;
 class IndexGraphLoaderImpl final : public IndexGraphLoader
 {
 public:
-  IndexGraphLoaderImpl(VehicleType vehicleType, bool loadAltitudes, bool isTwoThreadsReady,
+  IndexGraphLoaderImpl(VehicleType vehicleType, bool loadAltitudes, bool twoThreadsReady,
                        shared_ptr<NumMwmIds> numMwmIds,
                        shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory,
                        shared_ptr<EdgeEstimator> estimator, DataSource & dataSource,
@@ -85,7 +85,7 @@ private:
 };
 
 IndexGraphLoaderImpl::IndexGraphLoaderImpl(
-    VehicleType vehicleType, bool loadAltitudes, bool isTwoThreadsReady, shared_ptr<NumMwmIds> numMwmIds,
+    VehicleType vehicleType, bool loadAltitudes, bool twoThreadsReady, shared_ptr<NumMwmIds> numMwmIds,
     shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory,
     shared_ptr<EdgeEstimator> estimator, DataSource & dataSource,
     RoutingOptions routingOptions)
@@ -95,7 +95,7 @@ IndexGraphLoaderImpl::IndexGraphLoaderImpl(
   , m_numMwmIds(move(numMwmIds))
   , m_vehicleModelFactory(move(vehicleModelFactory))
   , m_estimator(move(estimator))
-  , m_graphsMtx(isTwoThreadsReady ? std::make_optional<std::mutex>() : std::nullopt)
+  , m_graphsMtx(twoThreadsReady ? std::make_optional<std::mutex>() : std::nullopt)
   , m_avoidRoutingOptions(routingOptions)
 {
   CHECK(m_numMwmIds, ());
@@ -274,12 +274,12 @@ namespace routing
 {
 // static
 unique_ptr<IndexGraphLoader> IndexGraphLoader::Create(
-    VehicleType vehicleType, bool loadAltitudes, bool isTwoThreadsReady, shared_ptr<NumMwmIds> numMwmIds,
+    VehicleType vehicleType, bool loadAltitudes, bool twoThreadsReady, shared_ptr<NumMwmIds> numMwmIds,
     shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory,
     shared_ptr<EdgeEstimator> estimator, DataSource & dataSource,
     RoutingOptions routingOptions)
 {
-  return make_unique<IndexGraphLoaderImpl>(vehicleType, loadAltitudes, isTwoThreadsReady, numMwmIds,
+  return make_unique<IndexGraphLoaderImpl>(vehicleType, loadAltitudes, twoThreadsReady, numMwmIds,
                                            vehicleModelFactory, estimator, dataSource,
                                            routingOptions);
 }

--- a/routing/index_graph_loader.cpp
+++ b/routing/index_graph_loader.cpp
@@ -40,6 +40,14 @@ public:
                        shared_ptr<EdgeEstimator> estimator, DataSource & dataSource,
                        RoutingOptions routingOptions = RoutingOptions());
 
+  /// |GetGeometry()| and |GetIndexGraph()| return a references to items in container |m_graphs|.
+  /// They may be called from different threads in case of two thread bidirectional A*.
+  /// The references they return are not constant but it's ok. The code should works with them
+  /// taking into account |isOutgoing| parameter. On the other hand these methods may add items to
+  /// |m_graphs| under a mutex. So it's possible that while one thread is working with a reference
+  /// returned by |GetGeometry()| or |GetIndexGraph()| the other thread is adding item to |m_graphs|
+  /// and the hash table is rehashing. Everything should work correctly because according
+  /// to the standard rehashing of std::unordered_map keeps references.
   // IndexGraphLoader overrides:
   Geometry & GetGeometry(NumMwmId numMwmId) override;
   IndexGraph & GetIndexGraph(NumMwmId numMwmId) override;

--- a/routing/index_graph_loader.cpp
+++ b/routing/index_graph_loader.cpp
@@ -211,7 +211,7 @@ IndexGraphLoaderImpl::GraphAttrs & IndexGraphLoaderImpl::CreateGeometry(NumMwmId
   auto & graph = m_graphs[numMwmId];
   graph.m_geometry = make_shared<Geometry>(
       GeometryLoader::Create(m_dataSource, handle, vehicleModel, AttrLoader(m_dataSource, handle),
-                             m_loadAltitudes), IsTwoThreadsReady());
+                             m_loadAltitudes, IsTwoThreadsReady()), IsTwoThreadsReady());
   return graph;
 }
 

--- a/routing/index_graph_loader.hpp
+++ b/routing/index_graph_loader.hpp
@@ -27,9 +27,11 @@ public:
   // Because several cameras can lie on one segment we return vector of them.
   virtual std::vector<RouteSegment::SpeedCamera> GetSpeedCameraInfo(Segment const & segment) = 0;
   virtual void Clear() = 0;
+  virtual bool IsTwoThreadsReady() const = 0;
 
   static std::unique_ptr<IndexGraphLoader> Create(
-      VehicleType vehicleType, bool loadAltitudes, std::shared_ptr<NumMwmIds> numMwmIds,
+      VehicleType vehicleType, bool loadAltitudes, bool twoThreadsReady,
+      std::shared_ptr<NumMwmIds> numMwmIds,
       std::shared_ptr<VehicleModelFactoryInterface> vehicleModelFactory,
       std::shared_ptr<EdgeEstimator> estimator, DataSource & dataSource,
       RoutingOptions routingOptions = RoutingOptions());

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -58,7 +58,7 @@ size_t IndexGraphStarter::GetRouteNumPoints(vector<Segment> const & segments)
 
 IndexGraphStarter::IndexGraphStarter(FakeEnding const & startEnding,
                                      FakeEnding const & finishEnding, uint32_t fakeNumerationStart,
-                                     bool strictForward, WorldGraph & graph)
+                                     bool strictForward, bool twoThreadsReady, WorldGraph & graph)
   : m_graph(graph)
 {
   m_fakeNumerationStart = fakeNumerationStart;

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -532,13 +532,13 @@ void IndexGraphStarter::AddFakeEdges(Segment const & segment, bool isOutgoing, v
     {
       //     |segment|       |s|
       //  *------------>*----------->
-      bool const sIsOutgoing =
-          GetJunction(segment, true /* front */) == GetJunction(s, false /* front */);
+      bool const sIsOutgoing = GetJunction(segment, true /* front */, isOutgoing) ==
+                               GetJunction(s, false /* front */, isOutgoing);
 
       //        |s|       |segment|
       //  *------------>*----------->
-      bool const sIsIngoing =
-          GetJunction(s, true /* front */) == GetJunction(segment, false /* front */);
+      bool const sIsIngoing = GetJunction(s, true /* front */, isOutgoing) ==
+                              GetJunction(segment, false /* front */, isOutgoing);
 
       if ((isOutgoing && sIsOutgoing) || (!isOutgoing && sIsIngoing))
       {

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -58,7 +58,7 @@ size_t IndexGraphStarter::GetRouteNumPoints(vector<Segment> const & segments)
 
 IndexGraphStarter::IndexGraphStarter(FakeEnding const & startEnding,
                                      FakeEnding const & finishEnding, uint32_t fakeNumerationStart,
-                                     bool strictForward, bool twoThreadsReady, WorldGraph & graph)
+                                     bool strictForward, WorldGraph & graph)
   : m_graph(graph)
 {
   m_fakeNumerationStart = fakeNumerationStart;

--- a/routing/index_graph_starter.cpp
+++ b/routing/index_graph_starter.cpp
@@ -71,8 +71,8 @@ IndexGraphStarter::IndexGraphStarter(FakeEnding const & startEnding,
   m_otherEndings.push_back(startEnding);
   m_otherEndings.push_back(finishEnding);
 
-  auto const startPoint = GetPoint(GetStartSegment(), false /* front */);
-  auto const finishPoint = GetPoint(GetFinishSegment(), true /* front */);
+  auto const startPoint = GetPoint(GetStartSegment(), false /* front */, true /* isOutgoing */);
+  auto const finishPoint = GetPoint(GetFinishSegment(), true /* front */, true /* isOutgoing */);
   m_startToFinishDistanceM = ms::DistanceOnEarth(startPoint, finishPoint);
 }
 
@@ -83,8 +83,8 @@ void IndexGraphStarter::Append(FakeEdgesContainer const & container)
 
   // It's important to calculate distance after m_fake.Append() because
   // we don't have finish segment in fake graph before m_fake.Append().
-  auto const startPoint = GetPoint(GetStartSegment(), false /* front */);
-  auto const finishPoint = GetPoint(GetFinishSegment(), true /* front */);
+  auto const startPoint = GetPoint(GetStartSegment(), false /* front */, true /* isOutgoing */);
+  auto const finishPoint = GetPoint(GetFinishSegment(), true /* front */, true /* isOutgoing */);
   m_startToFinishDistanceM = ms::DistanceOnEarth(startPoint, finishPoint);
   m_fakeNumerationStart += container.m_fake.GetSize();
 }
@@ -111,50 +111,51 @@ bool IndexGraphStarter::ConvertToReal(Segment & segment) const
   return m_fake.FindReal(Segment(segment), segment);
 }
 
-LatLonWithAltitude const & IndexGraphStarter::GetJunction(Segment const & segment, bool front) const
+LatLonWithAltitude const & IndexGraphStarter::GetJunction(Segment const & segment, bool front,
+                                                          bool isOutgoing) const
 {
   if (IsGuidesSegment(segment))
     return m_guides.GetJunction(segment, front);
 
   if (!IsFakeSegment(segment))
-    return m_graph.GetJunction(segment, front);
+    return m_graph.GetJunction(segment, front, isOutgoing);
 
   auto const & vertex = m_fake.GetVertex(segment);
   return front ? vertex.GetJunctionTo() : vertex.GetJunctionFrom();
 }
 
 LatLonWithAltitude const & IndexGraphStarter::GetRouteJunction(
-    vector<Segment> const & segments, size_t pointIndex) const
+    vector<Segment> const & segments, size_t pointIndex, bool isOutgoing) const
 {
   CHECK(!segments.empty(), ());
   CHECK_LESS_OR_EQUAL(
       pointIndex, segments.size(),
       ("Point with index", pointIndex, "does not exist in route with size", segments.size()));
   if (pointIndex == segments.size())
-    return GetJunction(segments[pointIndex - 1], true /* front */);
-  return GetJunction(segments[pointIndex], false);
+    return GetJunction(segments[pointIndex - 1], true /* front */, isOutgoing);
+  return GetJunction(segments[pointIndex], false /* front */, isOutgoing);
 }
 
-ms::LatLon const & IndexGraphStarter::GetPoint(Segment const & segment, bool front) const
+ms::LatLon const & IndexGraphStarter::GetPoint(Segment const & segment, bool front, bool isOutgoing) const
 {
-  return GetJunction(segment, front).GetLatLon();
+  return GetJunction(segment, front, isOutgoing).GetLatLon();
 }
 
-bool IndexGraphStarter::IsRoutingOptionsGood(Segment const & segment) const
+bool IndexGraphStarter::IsRoutingOptionsGood(Segment const & segment, bool isOutgoing) const
 {
-  return m_graph.IsRoutingOptionsGood(segment);
+  return m_graph.IsRoutingOptionsGood(segment, isOutgoing);
 }
 
-RoutingOptions IndexGraphStarter::GetRoutingOptions(Segment const & segment) const
+RoutingOptions IndexGraphStarter::GetRoutingOptions(Segment const & segment, bool isOutgoing) const
 {
   if (segment.IsRealSegment())
-    return m_graph.GetRoutingOptions(segment);
+    return m_graph.GetRoutingOptions(segment, isOutgoing);
 
   Segment real;
   if (!m_fake.FindReal(segment, real))
     return {};
 
-  return m_graph.GetRoutingOptions(real);
+  return m_graph.GetRoutingOptions(real, isOutgoing);
 }
 
 set<NumMwmId> IndexGraphStarter::GetMwms() const
@@ -179,12 +180,12 @@ set<NumMwmId> IndexGraphStarter::GetFinishMwms() const
   return mwms;
 }
 
-bool IndexGraphStarter::CheckLength(RouteWeight const & weight)
+bool IndexGraphStarter::CheckLength(RouteWeight const & weight, bool isOutgoing)
 {
   // We allow 1 pass-through/non-pass-through zone changes per ending located in
   // non-pass-through zone to allow user to leave this zone.
   int8_t const numPassThroughChangesAllowed =
-      (StartPassThroughAllowed() ? 0 : 1) + (FinishPassThroughAllowed() ? 0 : 1);
+      (StartPassThroughAllowed(isOutgoing) ? 0 : 1) + (FinishPassThroughAllowed(isOutgoing) ? 0 : 1);
 
   return weight.GetNumPassThroughChanges() <= numPassThroughChangesAllowed &&
          m_graph.CheckLength(weight, m_startToFinishDistanceM);
@@ -201,15 +202,17 @@ void IndexGraphStarter::GetEdgesList(astar::VertexData<Vertex, Weight> const & v
   // Weight used only when isOutgoing = false for passing to m_guides and placing to |edges|.
   RouteWeight ingoingSegmentWeight;
   if (!isOutgoing)
-    ingoingSegmentWeight = CalcSegmentWeight(segment, EdgeEstimator::Purpose::Weight);
+    ingoingSegmentWeight = CalcSegmentWeight(segment, isOutgoing, EdgeEstimator::Purpose::Weight);
 
   if (IsFakeSegment(segment))
   {
     Segment real;
     if (m_fake.FindReal(segment, real))
     {
-      bool const haveSameFront = GetJunction(segment, true /* front */) == GetJunction(real, true);
-      bool const haveSameBack = GetJunction(segment, false /* front */) == GetJunction(real, false);
+      bool const haveSameFront = GetJunction(segment, true /* front */, isOutgoing) ==
+                                 GetJunction(real, true /* front */, isOutgoing);
+      bool const haveSameBack = GetJunction(segment, false /* front */, isOutgoing) ==
+                                GetJunction(real, false /* front */, isOutgoing);
       if ((isOutgoing && haveSameFront) || (!isOutgoing && haveSameBack))
       {
         if (IsGuidesSegment(real))
@@ -227,8 +230,9 @@ void IndexGraphStarter::GetEdgesList(astar::VertexData<Vertex, Weight> const & v
 
     for (auto const & s : m_fake.GetEdges(segment, isOutgoing))
     {
-      edges.emplace_back(s, isOutgoing ? CalcSegmentWeight(s, EdgeEstimator::Purpose::Weight)
-                                       : ingoingSegmentWeight);
+      edges.emplace_back(s, isOutgoing
+                                ? CalcSegmentWeight(s, isOutgoing, EdgeEstimator::Purpose::Weight)
+                                : ingoingSegmentWeight);
     }
   }
   else if (IsGuidesSegment(segment))
@@ -254,22 +258,22 @@ RouteWeight IndexGraphStarter::CalcGuidesSegmentWeight(Segment const & segment,
   return m_graph.CalcOffroadWeight(from.GetLatLon(), to.GetLatLon(), purpose);
 }
 
-RouteWeight IndexGraphStarter::CalcSegmentWeight(Segment const & segment,
+RouteWeight IndexGraphStarter::CalcSegmentWeight(Segment const & segment, bool isOutgoing,
                                                  EdgeEstimator::Purpose purpose) const
 {
   if (IsGuidesSegment(segment))
     return CalcGuidesSegmentWeight(segment, purpose);
 
   if (!IsFakeSegment(segment))
-    return m_graph.CalcSegmentWeight(segment, purpose);
+    return m_graph.CalcSegmentWeight(segment, isOutgoing, purpose);
 
   auto const & vertex = m_fake.GetVertex(segment);
   Segment real;
   if (m_fake.FindReal(segment, real))
   {
     auto const partLen = ms::DistanceOnEarth(vertex.GetPointFrom(), vertex.GetPointTo());
-    auto const fullLen =
-        ms::DistanceOnEarth(GetPoint(real, false /* front */), GetPoint(real, true /* front */));
+    auto const fullLen = ms::DistanceOnEarth(GetPoint(real, false /* front */, isOutgoing),
+                                             GetPoint(real, true /* front */, isOutgoing));
     // Note 1. |fullLen| == 0.0 in case of Segment(s) with the same ends.
     // Note 2. There is the following logic behind |return 0.0 * m_graph.CalcSegmentWeight(real, ...);|:
     // it's necessary to return a instance of the structure |RouteWeight| with zero wight.
@@ -277,7 +281,7 @@ RouteWeight IndexGraphStarter::CalcSegmentWeight(Segment const & segment,
     // may be kept in it and it is up to |RouteWeight| to know how to multiply by zero.
 
     Weight const weight = IsGuidesSegment(real) ? CalcGuidesSegmentWeight(real, purpose)
-                                                : m_graph.CalcSegmentWeight(real, purpose);
+                                                : m_graph.CalcSegmentWeight(real, isOutgoing, purpose);
     if (fullLen == 0.0)
       return 0.0 * weight;
 
@@ -287,14 +291,14 @@ RouteWeight IndexGraphStarter::CalcSegmentWeight(Segment const & segment,
   return m_graph.CalcOffroadWeight(vertex.GetPointFrom(), vertex.GetPointTo(), purpose);
 }
 
-double IndexGraphStarter::CalculateETA(Segment const & from, Segment const & to) const
+double IndexGraphStarter::CalculateETA(Segment const & from, Segment const & to, bool isOutgoing) const
 {
   // We don't distinguish fake segment weight and fake segment transit time.
   if (IsFakeSegment(to))
-    return CalcSegmentWeight(to, EdgeEstimator::Purpose::ETA).GetWeight();
+    return CalcSegmentWeight(to, isOutgoing, EdgeEstimator::Purpose::ETA).GetWeight();
 
   if (IsFakeSegment(from))
-    return CalculateETAWithoutPenalty(to);
+    return CalculateETAWithoutPenalty(to, isOutgoing);
 
   if (IsGuidesSegment(from) || IsGuidesSegment(to))
   {
@@ -302,28 +306,28 @@ double IndexGraphStarter::CalculateETA(Segment const & from, Segment const & to)
     if (IsGuidesSegment(from))
       res += CalcGuidesSegmentWeight(from, EdgeEstimator::Purpose::ETA).GetWeight();
     else
-      res += CalculateETAWithoutPenalty(from);
+      res += CalculateETAWithoutPenalty(from, isOutgoing);
 
     if (IsGuidesSegment(to))
       res += CalcGuidesSegmentWeight(to, EdgeEstimator::Purpose::ETA).GetWeight();
     else
-      res += CalculateETAWithoutPenalty(to);
+      res += CalculateETAWithoutPenalty(to, isOutgoing);
 
     return res;
   }
 
-  return m_graph.CalculateETA(from, to);
+  return m_graph.CalculateETA(from, to, isOutgoing);
 }
 
-double IndexGraphStarter::CalculateETAWithoutPenalty(Segment const & segment) const
+double IndexGraphStarter::CalculateETAWithoutPenalty(Segment const & segment, bool isOutgoing) const
 {
   if (IsFakeSegment(segment))
-    return CalcSegmentWeight(segment, EdgeEstimator::Purpose::ETA).GetWeight();
+    return CalcSegmentWeight(segment, isOutgoing, EdgeEstimator::Purpose::ETA).GetWeight();
 
   if (IsGuidesSegment(segment))
     return CalcGuidesSegmentWeight(segment, EdgeEstimator::Purpose::ETA).GetWeight();
 
-  return m_graph.CalculateETAWithoutPenalty(segment);
+  return m_graph.CalculateETAWithoutPenalty(segment, isOutgoing);
 }
 
 void IndexGraphStarter::AddEnding(FakeEnding const & thisEnding)
@@ -540,31 +544,32 @@ void IndexGraphStarter::AddFakeEdges(Segment const & segment, bool isOutgoing, v
       {
         // For ingoing edges we use source weight which is the same for |s| and for |edge| and is
         // already calculated.
-        fakeEdges.emplace_back(s, isOutgoing ? CalcSegmentWeight(s, EdgeEstimator::Purpose::Weight)
-                                             : edge.GetWeight());
+        fakeEdges.emplace_back(
+            s, isOutgoing ? CalcSegmentWeight(s, isOutgoing, EdgeEstimator::Purpose::Weight)
+                          : edge.GetWeight());
       }
     }
   }
   edges.insert(edges.end(), fakeEdges.begin(), fakeEdges.end());
 }
 
-bool IndexGraphStarter::EndingPassThroughAllowed(Ending const & ending)
+bool IndexGraphStarter::EndingPassThroughAllowed(Ending const & ending, bool isOutgoing)
 {
-  return any_of(ending.m_real.cbegin(), ending.m_real.cend(), [this](Segment const & s) {
+  return any_of(ending.m_real.cbegin(), ending.m_real.cend(), [this, isOutgoing](Segment const & s) {
     if (IsGuidesSegment(s))
       return true;
-    return m_graph.IsPassThroughAllowed(s.GetMwmId(), s.GetFeatureId());
+    return m_graph.IsPassThroughAllowed(s.GetMwmId(), s.GetFeatureId(), isOutgoing);
   });
 }
 
-bool IndexGraphStarter::StartPassThroughAllowed()
+bool IndexGraphStarter::StartPassThroughAllowed(bool isOutgoing)
 {
-  return EndingPassThroughAllowed(m_start);
+  return EndingPassThroughAllowed(m_start, isOutgoing);
 }
 
-bool IndexGraphStarter::FinishPassThroughAllowed()
+bool IndexGraphStarter::FinishPassThroughAllowed(bool isOutgoing)
 {
-  return EndingPassThroughAllowed(m_finish);
+  return EndingPassThroughAllowed(m_finish, isOutgoing);
 }
 
 Segment IndexGraphStarter::GetFakeSegmentAndIncr()

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -176,14 +176,14 @@ public:
                                        std::move(fakeFeatureConverter));
   }
 
-  bool IsJoint(Segment const & segment, bool fromStart)
+  bool IsJoint(Segment const & segment, bool fromStart, bool isOutgoing)
   {
     return GetGraph().GetIndexGraph(segment.GetMwmId()).IsJoint(segment.GetRoadPoint(fromStart));
   }
 
-  bool IsJointOrEnd(Segment const & segment, bool fromStart)
+  bool IsJointOrEnd(Segment const & segment, bool fromStart, bool isOutgoing)
   {
-    return GetGraph().GetIndexGraph(segment.GetMwmId()).IsJointOrEnd(segment, fromStart);
+    return GetGraph().GetIndexGraph(segment.GetMwmId()).IsJointOrEnd(segment, fromStart, isOutgoing);
   }
   // @}
 

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -57,8 +57,7 @@ public:
   // vertex. true: place exactly one fake edge to the m_segment indicated with m_forward. false:
   // place two fake edges to the m_segment with both directions.
   IndexGraphStarter(FakeEnding const & startEnding, FakeEnding const & finishEnding,
-                    uint32_t fakeNumerationStart, bool strictForward, bool twoThreadsReady,
-                    WorldGraph & graph);
+                    uint32_t fakeNumerationStart, bool strictForward, WorldGraph & graph);
 
   void Append(FakeEdgesContainer const & container);
 
@@ -143,6 +142,8 @@ public:
   }
 
   RouteWeight GetAStarWeightEpsilon() override;
+
+  bool IsTwoThreadsReady() const override { return m_graph.IsTwoThreadsReady(); }
   // @}
 
   void GetEdgesList(Vertex const & vertex, bool isOutgoing, std::vector<SegmentEdge> & edges) const

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -95,6 +95,9 @@ public:
 
   // Checks whether |weight| meets non-pass-through crossing restrictions according to placement of
   // start and finish in pass-through/non-pass-through area and number of non-pass-through crosses.
+  // Note. CheckLength() may be called from two different threads according to |isOutgoing|
+  // but it no need additional synchronization. Although |m_start| and |m_finish| may be
+  // used from two different threads while route building they are used only for reading.
   bool CheckLength(RouteWeight const & weight, bool isOutgoing);
 
   void GetEdgeList(astar::VertexData<JointSegment, Weight> const & parentVertexData,

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -73,13 +73,13 @@ public:
   // If segment is part of real converts it to real and returns true.
   // Otherwise returns false and does not modify segment.
   bool ConvertToReal(Segment & segment) const;
-  LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) const;
-  LatLonWithAltitude const & GetRouteJunction(std::vector<Segment> const & route,
-                                                       size_t pointIndex) const;
-  ms::LatLon const & GetPoint(Segment const & segment, bool front) const;
+  LatLonWithAltitude const & GetJunction(Segment const & segment, bool front, bool isOutgoing) const;
+  LatLonWithAltitude const & GetRouteJunction(std::vector<Segment> const & route, size_t pointIndex,
+                                              bool isOutgoing) const;
+  ms::LatLon const & GetPoint(Segment const & segment, bool front, bool isOutgoing) const;
 
-  bool IsRoutingOptionsGood(Segment const & segment) const;
-  RoutingOptions GetRoutingOptions(Segment const & segment) const;
+  bool IsRoutingOptionsGood(Segment const & segment, bool isOutgoing) const;
+  RoutingOptions GetRoutingOptions(Segment const & segment, bool isOutgoing) const;
 
   uint32_t GetNumFakeSegments() const
   {
@@ -95,7 +95,7 @@ public:
 
   // Checks whether |weight| meets non-pass-through crossing restrictions according to placement of
   // start and finish in pass-through/non-pass-through area and number of non-pass-through crosses.
-  bool CheckLength(RouteWeight const & weight);
+  bool CheckLength(RouteWeight const & weight, bool isOutgoing);
 
   void GetEdgeList(astar::VertexData<JointSegment, Weight> const & parentVertexData,
                    Segment const & segment, bool isOutgoing, std::vector<JointEdge> & edges,
@@ -119,10 +119,10 @@ public:
     GetEdgesList(vertexData, false /* isOutgoing */, true /* useAccessConditional */, edges);
   }
 
-  RouteWeight HeuristicCostEstimate(Vertex const & from, Vertex const & to) override
+  RouteWeight HeuristicCostEstimate(Vertex const & from, Vertex const & to, bool isOutgoing) override
   {
-    return m_graph.HeuristicCostEstimate(GetPoint(from, true /* front */),
-                                         GetPoint(to, true /* front */));
+    return m_graph.HeuristicCostEstimate(GetPoint(from, true /* front */, isOutgoing),
+                                         GetPoint(to, true /* front */, isOutgoing));
   }
 
   void SetAStarParents(bool forward, Parents<Segment> & parents) override
@@ -149,16 +149,17 @@ public:
     GetEdgesList({vertex, Weight(0.0)}, isOutgoing, false /* useAccessConditional */, edges);
   }
 
-  RouteWeight HeuristicCostEstimate(Vertex const & from, ms::LatLon const & to) const
+  RouteWeight HeuristicCostEstimate(Vertex const & from, ms::LatLon const & to, bool isOutgoing) const
   {
-    return m_graph.HeuristicCostEstimate(GetPoint(from, true /* front */), to);
+    return m_graph.HeuristicCostEstimate(GetPoint(from, true /* front */, isOutgoing), to);
   }
 
-  RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) const;
+  RouteWeight CalcSegmentWeight(Segment const & segment, bool isOutgoing,
+                                EdgeEstimator::Purpose purpose) const;
   RouteWeight CalcGuidesSegmentWeight(Segment const & segment,
                                       EdgeEstimator::Purpose purpose) const;
-  double CalculateETA(Segment const & from, Segment const & to) const;
-  double CalculateETAWithoutPenalty(Segment const & segment) const;
+  double CalculateETA(Segment const & from, Segment const & to, bool isOutgoing) const;
+  double CalculateETAWithoutPenalty(Segment const & segment, bool isOutgoing) const;
 
   // For compatibility with IndexGraphStarterJoints
   // @{
@@ -240,11 +241,11 @@ private:
   void AddFakeEdges(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges) const;
 
   // Checks whether ending belongs to pass-through or non-pass-through zone.
-  bool EndingPassThroughAllowed(Ending const & ending);
+  bool EndingPassThroughAllowed(Ending const & ending, bool isOutgoing);
   // Start segment is located in a pass-through/non-pass-through area.
-  bool StartPassThroughAllowed();
+  bool StartPassThroughAllowed(bool isOutgoing);
   // Finish segment is located in a pass-through/non-pass-through area.
-  bool FinishPassThroughAllowed();
+  bool FinishPassThroughAllowed(bool isOutgoing);
 
   static uint32_t constexpr kFakeFeatureId = FakeFeatureIds::kIndexGraphStarterId;
   WorldGraph & m_graph;

--- a/routing/index_graph_starter.hpp
+++ b/routing/index_graph_starter.hpp
@@ -57,7 +57,8 @@ public:
   // vertex. true: place exactly one fake edge to the m_segment indicated with m_forward. false:
   // place two fake edges to the m_segment with both directions.
   IndexGraphStarter(FakeEnding const & startEnding, FakeEnding const & finishEnding,
-                    uint32_t fakeNumerationStart, bool strictForward, WorldGraph & graph);
+                    uint32_t fakeNumerationStart, bool strictForward, bool twoThreadsReady,
+                    WorldGraph & graph);
 
   void Append(FakeEdgesContainer const & container);
 

--- a/routing/index_graph_starter_joints.hpp
+++ b/routing/index_graph_starter_joints.hpp
@@ -40,13 +40,13 @@ public:
 
   void Init(Segment const & startSegment, Segment const & endSegment);
 
-  ms::LatLon const & GetPoint(JointSegment const & jointSegment, bool start);
+  ms::LatLon const & GetPoint(JointSegment const & jointSegment, bool start, bool isOutgoing);
   JointSegment const & GetStartJoint() const { return m_startJoint; }
   JointSegment const & GetFinishJoint() const { return m_endJoint; }
 
   // AStarGraph overridings
   // @{
-  RouteWeight HeuristicCostEstimate(Vertex const & from, Vertex const & to) override;
+  RouteWeight HeuristicCostEstimate(Vertex const & from, Vertex const & to, bool isOutgoing) override;
 
   void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
                             std::vector<Edge> & edges) override
@@ -259,7 +259,7 @@ void IndexGraphStarterJoints<Graph>::InitEnding(Segment const & ending, bool sta
   segment = ending;
 
   auto & point = start ? m_startPoint : m_endPoint;
-  point = m_graph.GetPoint(ending, true /* front */);
+  point = m_graph.GetPoint(ending, true /* front */, true /* isOutgoing */);
 
   auto & endingJoint = start ? m_startJoint : m_endJoint;
   if (IsRealSegment(ending))
@@ -287,7 +287,8 @@ void IndexGraphStarterJoints<Graph>::InitEnding(Segment const & ending, bool sta
 
 template <typename Graph>
 RouteWeight IndexGraphStarterJoints<Graph>::HeuristicCostEstimate(JointSegment const & from,
-                                                                  JointSegment const & to)
+                                                                  JointSegment const & to,
+                                                                  bool isOutgoing)
 {
   ASSERT(to == m_startJoint || to == m_endJoint, ("Invariant violated."));
   bool toEnd = to == m_endJoint;
@@ -303,18 +304,18 @@ RouteWeight IndexGraphStarterJoints<Graph>::HeuristicCostEstimate(JointSegment c
     fromSegment = from.GetSegment(false /* start */);
   }
 
-  return toEnd ? m_graph.HeuristicCostEstimate(fromSegment, m_endPoint)
-               : m_graph.HeuristicCostEstimate(fromSegment, m_startPoint);
+  return toEnd ? m_graph.HeuristicCostEstimate(fromSegment, m_endPoint, isOutgoing)
+               : m_graph.HeuristicCostEstimate(fromSegment, m_startPoint, isOutgoing);
 }
 
 template <typename Graph>
 ms::LatLon const &
-IndexGraphStarterJoints<Graph>::GetPoint(JointSegment const & jointSegment, bool start)
+IndexGraphStarterJoints<Graph>::GetPoint(JointSegment const & jointSegment, bool start, bool isOutgoing)
 {
   Segment segment = jointSegment.IsFake() ? m_fakeJointSegments[jointSegment].GetSegment(start)
                                           : jointSegment.GetSegment(start);
 
-  return m_graph.GetPoint(segment, jointSegment.IsForward());
+  return m_graph.GetPoint(segment, jointSegment.IsForward(), isOutgoing);
 }
 
 template <typename Graph>
@@ -617,11 +618,11 @@ std::vector<JointEdge> IndexGraphStarterJoints<Graph>::FindFirstJoints(Segment c
   {
     CHECK(!IsRealSegment(fake), ());
 
-    bool const hasSameFront =
-        m_graph.GetPoint(fake, true /* front */) == m_graph.GetPoint(segment, true);
+    bool const hasSameFront = m_graph.GetPoint(fake, true /* front */, true /* isOutgoing */) ==
+                              m_graph.GetPoint(segment, true /* front */, true /* isOutgoing */);
 
-    bool const hasSameBack =
-        m_graph.GetPoint(fake, false /* front */) == m_graph.GetPoint(segment, false);
+    bool const hasSameBack = m_graph.GetPoint(fake, false /* front */, true /* isOutgoing */) ==
+                             m_graph.GetPoint(segment, false /* front */, true /* isOutgoing */);
 
     return (fromStart && hasSameFront) || (!fromStart && hasSameBack);
   };

--- a/routing/index_graph_starter_joints.hpp
+++ b/routing/index_graph_starter_joints.hpp
@@ -142,14 +142,14 @@ private:
 
   JointSegment CreateFakeJoint(Segment const & from, Segment const & to);
 
-  bool IsJoint(Segment const & segment, bool fromStart) const
+  bool IsJoint(Segment const & segment, bool fromStart, bool isOutgoing) const
   {
-    return m_graph.IsJoint(segment, fromStart);
+    return m_graph.IsJoint(segment, fromStart, isOutgoing);
   }
 
-  bool IsJointOrEnd(Segment const & segment, bool fromStart) const
+  bool IsJointOrEnd(Segment const & segment, bool fromStart, bool isOutgoing) const
   {
-    return m_graph.IsJointOrEnd(segment, fromStart);
+    return m_graph.IsJointOrEnd(segment, fromStart, isOutgoing);
   }
 
   bool FillEdgesAndParentsWeights(astar::VertexData<Vertex, Weight> const & vertexData,
@@ -163,7 +163,7 @@ private:
 
   /// \brief Makes BFS from |startSegment| in direction |fromStart| and find the closest segments
   /// which end RoadPoints are joints. Thus we build fake joint segments graph.
-  std::vector<JointEdge> FindFirstJoints(Segment const & startSegment, bool fromStart);
+  std::vector<JointEdge> FindFirstJoints(Segment const & startSegment, bool fromStart, bool isOutgoing);
 
   JointSegment CreateInvisibleJoint(Segment const & segment, bool start);
 
@@ -275,7 +275,7 @@ void IndexGraphStarterJoints<Graph>::InitEnding(Segment const & ending, bool sta
   m_reconstructedFakeJoints[endingJoint] = ReconstructedPath({ending}, start);
 
   auto & outEdges = start ? m_startOutEdges : m_endOutEdges;
-  outEdges = FindFirstJoints(ending, start);
+  outEdges = FindFirstJoints(ending, start, true /* isOutgoing */);
 
   if (!start)
   {
@@ -569,7 +569,7 @@ JointSegment IndexGraphStarterJoints<Graph>::CreateFakeJoint(Segment const & fro
 
 template <typename Graph>
 std::vector<JointEdge> IndexGraphStarterJoints<Graph>::FindFirstJoints(Segment const & startSegment,
-                                                                       bool fromStart)
+                                                                       bool fromStart, bool isOutgoing)
 {
   Segment const & endSegment = fromStart ? m_endSegment : m_startSegment;
 
@@ -636,7 +636,7 @@ std::vector<JointEdge> IndexGraphStarterJoints<Graph>::FindFirstJoints(Segment c
     // or it's the real one and its end (RoadPoint) is |Joint|.
     if (((!IsRealSegment(segment) && m_graph.ConvertToReal(segment) &&
           isEndOfSegment(beforeConvert, segment, fromStart)) || IsRealSegment(beforeConvert)) &&
-        IsJoint(segment, fromStart))
+        IsJoint(segment, fromStart, isOutgoing))
     {
       addFake(segment, beforeConvert);
       continue;

--- a/routing/index_graph_starter_joints.hpp
+++ b/routing/index_graph_starter_joints.hpp
@@ -32,9 +32,9 @@ template <typename Graph>
 class IndexGraphStarterJoints : public AStarGraph<JointSegment, JointEdge, RouteWeight>
 {
 public:
-  /// \note This class may be used in two modes. For one thread A* nd two thread A*.
+  /// \note This class may be used in two modes. For one thread A* and two threads A*.
   /// To create an instance of the class with synchronization staff |twoThreadsReady|
-  /// Should be set to true. It means the class is ready for calls HeuristicCostEstimate(),
+  /// should be set to true. It means the class is ready for calls HeuristicCostEstimate(),
   /// GetOutgoingEdgesList() and GetIngoingEdgesList() from two different threads.
   explicit IndexGraphStarterJoints(Graph & graph)
     : m_graph(graph), m_reconstructedFakeJointsMtx(std::nullopt)

--- a/routing/index_graph_starter_joints.hpp
+++ b/routing/index_graph_starter_joints.hpp
@@ -245,7 +245,7 @@ private:
 template <typename Graph>
 std::optional<std::mutex> GetOptionalMutex(Graph const & graph)
 {
-  return graph.IsTwoThreadsReady() ? std::optional<std::mutex>() : std::nullopt;
+  return graph.IsTwoThreadsReady() ? std::make_optional<std::mutex>() : std::nullopt;
 }
 
 template <typename Graph>

--- a/routing/index_road_graph.cpp
+++ b/routing/index_road_graph.cpp
@@ -97,9 +97,11 @@ void IndexRoadGraph::GetRouteEdges(EdgeVector & edges) const
   for (Segment const & segment : m_segments)
   {
     auto const & junctionFrom =
-        m_starter.GetJunction(segment, false /* front */).ToPointWithAltitude();
+        m_starter.GetJunction(segment, false /* front */, true /* isOutgoing */)
+            .ToPointWithAltitude();
     auto const & junctionTo =
-        m_starter.GetJunction(segment, true /* front */).ToPointWithAltitude();
+        m_starter.GetJunction(segment, true /* front */, true /* isOutgoing */)
+            .ToPointWithAltitude();
 
     if (IndexGraphStarter::IsFakeSegment(segment) || TransitGraph::IsTransitSegment(segment))
     {
@@ -159,8 +161,8 @@ void IndexRoadGraph::GetEdges(geometry::PointWithAltitude const & junction, bool
 
     edges.push_back(Edge::MakeReal(
         FeatureID(mwmId, segment.GetFeatureId()), segment.IsForward(), segment.GetSegmentIdx(),
-        m_starter.GetJunction(segment, false /* front */).ToPointWithAltitude(),
-        m_starter.GetJunction(segment, true /* front */).ToPointWithAltitude()));
+        m_starter.GetJunction(segment, false /* front */, isOutgoing).ToPointWithAltitude(),
+        m_starter.GetJunction(segment, true /* front */, isOutgoing).ToPointWithAltitude()));
   }
 }
 

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -645,7 +645,7 @@ RouterResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoints,
     // Stop building route if |finishCheckpoint| is not connected to OSM and is not connected to
     // the guides graph.
     if (!FindBestSegments(finishCheckpoint, m2::PointD::Zero() /* direction */,
-                          false /* isOutgoing */, *graph, finishSegments,
+                          true /* isOutgoing */, *graph, finishSegments,
                           dummy /* bestSegmentIsAlmostCodirectional */) &&
         finishFakeEnding.m_projections.empty())
     {

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -604,8 +604,6 @@ RouterResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoints,
 
   vector<Segment> startSegments;
   bool startSegmentIsAlmostCodirectionalDirection = false;
-  // @TODO |startSegments| and |finishSegments| may be found in two threads with the help of
-  // |graph| with two threads support.
   bool const foundStart =
       FindBestSegments(checkpoints.GetPointFrom(), startDirection, true /* isOutgoing */, *graph,
                        startSegments, startSegmentIsAlmostCodirectionalDirection);

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -653,8 +653,7 @@ RouterResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoints,
     uint32_t const fakeNumerationStart =
         starter ? starter->GetNumFakeSegments() + startIdx : startIdx;
     IndexGraphStarter subrouteStarter(startFakeEnding, finishFakeEnding, fakeNumerationStart,
-                                      isStartSegmentStrictForward, false /* twoThreadsReady */,
-                                      *graph);
+                                      isStartSegmentStrictForward, *graph);
 
     if (m_guides.IsAttached())
     {
@@ -913,7 +912,7 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
   FakeEnding dummy{};
   IndexGraphStarter starter(MakeFakeEnding(startSegments, pointFrom, *graph), dummy,
                             m_lastFakeEdges->GetNumFakeEdges(), bestSegmentIsAlmostCodirectional,
-                            false /* twoThreadsReady */, *graph);
+                            *graph);
 
   starter.Append(*m_lastFakeEdges);
 
@@ -1004,7 +1003,7 @@ unique_ptr<WorldGraph> IndexRouter::MakeWorldGraph()
   if (m_vehicleType != VehicleType::Transit)
   {
     auto graph = make_unique<SingleVehicleWorldGraph>(
-        move(crossMwmGraph), move(indexGraphLoader), m_estimator,
+        move(crossMwmGraph), move(indexGraphLoader), m_estimator, false /* twoThreadsReady */,
         MwmHierarchyHandler(m_numMwmIds, m_countryParentNameGetterFn));
     graph->SetRoutingOptions(routingOptions);
     return graph;

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -905,7 +905,7 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
 {
   base::Timer timer;
   TrafficStash::Guard guard(m_trafficStash);
-  auto graph = MakeWorldGraph(false /* isTwoThreadsReady */);
+  auto graph = MakeWorldGraph(false /* twoThreadsReady */);
   graph->SetMode(WorldGraphMode::NoLeaps);
 
   vector<Segment> startSegments;

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -412,7 +412,8 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints,
     {
       LOG(LINFO, ("---------------------", twoThreadsReady ? "Two threads" : "One threads", "---------------------"));
       // TODO |twoThreadsReady| is passed to DoCalculateRoute(), CalculateSubroute() and
-      // to CalculateSubrouteJointsMode() for test purposes only.
+      // to CalculateSubrouteJointsMode() for test purposes only. It should be removed in
+      // these methods.
       lastReturn = DoCalculateRoute(checkpoints, startDirection, delegate, twoThreadsReady, route);
       LOG(LINFO, ("---------------------", twoThreadsReady ? "Two threads" : "One threads", "END---------------------"));
     }

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -414,6 +414,7 @@ RouterResultCode IndexRouter::CalculateRoute(Checkpoints const & checkpoints,
       // TODO |twoThreadsReady| is passed to DoCalculateRoute(), CalculateSubroute() and
       // to CalculateSubrouteJointsMode() for test purposes only. It should be removed in
       // these methods.
+      m_guides.Clear();
       lastReturn = DoCalculateRoute(checkpoints, startDirection, delegate, twoThreadsReady, route);
       LOG(LINFO, ("---------------------", twoThreadsReady ? "Two threads" : "One threads", "END---------------------"));
     }
@@ -844,7 +845,7 @@ RouterResultCode IndexRouter::CalculateSubrouteNoLeapsMode(
   RoutingResult<Vertex, Weight> routingResult;
   set<NumMwmId> const mwmIds = starter.GetMwms();
   RouterResultCode const result =
-      FindPath<Vertex, Edge, Weight>(false /* useTwoThreads */, params, mwmIds, routingResult,
+      FindPath<Vertex, Edge, Weight>(starter.IsTwoThreadsReady(), params, mwmIds, routingResult,
                                      WorldGraphMode::NoLeaps);
 
   if (result != RouterResultCode::NoError)
@@ -880,7 +881,7 @@ RouterResultCode IndexRouter::CalculateSubrouteLeapsOnlyMode(
 
   RoutingResult<Vertex, Weight> routingResult;
   RouterResultCode const result =
-      FindPath<Vertex, Edge, Weight>(false /* useTwoThreads */, params, {} /* mwmIds */,
+      FindPath<Vertex, Edge, Weight>(leapsGraph.IsTwoThreadsReady(), params, {} /* mwmIds */,
                                      routingResult, WorldGraphMode::LeapsOnly);
 
   progress->PushAndDropLastSubProgress();
@@ -1369,7 +1370,7 @@ RouterResultCode IndexRouter::ProcessLeapsJoints(vector<Segment> const & input,
         nullptr /* prevRoute */, delegate.GetCancellable(), move(visitor),
         AStarLengthChecker(starter));
 
-    resultCode = FindPath<Vertex, Edge, Weight>(true /* useTwoThreads */, params, mwmIds,
+    resultCode = FindPath<Vertex, Edge, Weight>(jointStarter.IsTwoThreadsReady(), params, mwmIds,
                                                 routingResult, mode);
     return resultCode;
   };

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -786,8 +786,7 @@ RouterResultCode IndexRouter::CalculateSubrouteJointsMode(
     shared_ptr<AStarProgress> const & progress, vector<Segment> & subroute)
 {
   using JointsStarter = IndexGraphStarterJoints<IndexGraphStarter>;
-  JointsStarter jointStarter(starter, starter.GetStartSegment(), starter.GetFinishSegment(),
-                             starter.IsTwoThreadsReady());
+  JointsStarter jointStarter(starter, starter.GetStartSegment(), starter.GetFinishSegment());
 
   using Visitor = JunctionVisitor<JointsStarter>;
   Visitor visitor(jointStarter, delegate, kVisitPeriod, progress);

--- a/routing/index_router.cpp
+++ b/routing/index_router.cpp
@@ -653,7 +653,8 @@ RouterResultCode IndexRouter::DoCalculateRoute(Checkpoints const & checkpoints,
     uint32_t const fakeNumerationStart =
         starter ? starter->GetNumFakeSegments() + startIdx : startIdx;
     IndexGraphStarter subrouteStarter(startFakeEnding, finishFakeEnding, fakeNumerationStart,
-                                      isStartSegmentStrictForward, *graph);
+                                      isStartSegmentStrictForward, false /* twoThreadsReady */,
+                                      *graph);
 
     if (m_guides.IsAttached())
     {
@@ -785,7 +786,8 @@ RouterResultCode IndexRouter::CalculateSubrouteJointsMode(
     shared_ptr<AStarProgress> const & progress, vector<Segment> & subroute)
 {
   using JointsStarter = IndexGraphStarterJoints<IndexGraphStarter>;
-  JointsStarter jointStarter(starter, starter.GetStartSegment(), starter.GetFinishSegment());
+  JointsStarter jointStarter(starter, starter.GetStartSegment(), starter.GetFinishSegment(),
+                             starter.IsTwoThreadsReady());
 
   using Visitor = JunctionVisitor<JointsStarter>;
   Visitor visitor(jointStarter, delegate, kVisitPeriod, progress);
@@ -912,7 +914,7 @@ RouterResultCode IndexRouter::AdjustRoute(Checkpoints const & checkpoints,
   FakeEnding dummy{};
   IndexGraphStarter starter(MakeFakeEnding(startSegments, pointFrom, *graph), dummy,
                             m_lastFakeEdges->GetNumFakeEdges(), bestSegmentIsAlmostCodirectional,
-                            *graph);
+                            false /* twoThreadsReady */, *graph);
 
   starter.Append(*m_lastFakeEdges);
 

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -104,7 +104,6 @@ private:
   RouterResultCode CalculateSubrouteJointsMode(IndexGraphStarter & starter,
                                                RouterDelegate const & delegate,
                                                std::shared_ptr<AStarProgress> const & progress,
-                                               bool twoThreadsReady,
                                                std::vector<Segment> & subroute);
   RouterResultCode CalculateSubrouteNoLeapsMode(IndexGraphStarter & starter,
                                                 RouterDelegate const & delegate,
@@ -124,7 +123,7 @@ private:
                                      RouterDelegate const & delegate,
                                      std::shared_ptr<AStarProgress> const & progress,
                                      IndexGraphStarter & graph, std::vector<Segment> & subroute,
-                                     bool twoThreadsReady, bool guidesActive = false);
+                                     bool guidesActive = false);
 
   RouterResultCode AdjustRoute(Checkpoints const & checkpoints,
                                m2::PointD const & startDirection,
@@ -209,15 +208,14 @@ private:
   }
 
   template <typename Vertex, typename Edge, typename Weight, typename AStarParams>
-  RouterResultCode FindPath(bool useTwoThreads, AStarParams & params,
-                            std::set<NumMwmId> const & mwmIds,
+  RouterResultCode FindPath(AStarParams & params, std::set<NumMwmId> const & mwmIds,
                             RoutingResult<Vertex, Weight> & routingResult,
                             WorldGraphMode mode) const
   {
     AStarAlgorithm<Vertex, Edge, Weight> algorithm;
     return ConvertTransitResult(
         mwmIds, ConvertResult<Vertex, Edge, Weight>(
-                    algorithm.FindPathBidirectional(useTwoThreads, params, routingResult)));
+                    algorithm.FindPathBidirectional(params, routingResult)));
   }
 
   void SetupAlgorithmMode(IndexGraphStarter & starter, bool guidesActive = false) const;

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -117,7 +117,8 @@ private:
 
   RouterResultCode DoCalculateRoute(Checkpoints const & checkpoints,
                                     m2::PointD const & startDirection,
-                                    RouterDelegate const & delegate, Route & route);
+                                    RouterDelegate const & delegate, bool twoThreadsReady,
+                                    Route & route);
   RouterResultCode CalculateSubroute(Checkpoints const & checkpoints, size_t subrouteIdx,
                                      RouterDelegate const & delegate,
                                      std::shared_ptr<AStarProgress> const & progress,
@@ -128,7 +129,7 @@ private:
                                m2::PointD const & startDirection,
                                RouterDelegate const & delegate, Route & route);
 
-  std::unique_ptr<WorldGraph> MakeWorldGraph(bool isTwoThreadsReady);
+  std::unique_ptr<WorldGraph> MakeWorldGraph(bool twoThreadsReady);
 
   /// \brief Removes all roads from |roads| which goes to dead ends and all road which
   /// is not good according to |worldGraph|. For car routing there are roads with hwtag nocar as well.

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -104,6 +104,7 @@ private:
   RouterResultCode CalculateSubrouteJointsMode(IndexGraphStarter & starter,
                                                RouterDelegate const & delegate,
                                                std::shared_ptr<AStarProgress> const & progress,
+                                               bool twoThreadsReady,
                                                std::vector<Segment> & subroute);
   RouterResultCode CalculateSubrouteNoLeapsMode(IndexGraphStarter & starter,
                                                 RouterDelegate const & delegate,
@@ -123,7 +124,7 @@ private:
                                      RouterDelegate const & delegate,
                                      std::shared_ptr<AStarProgress> const & progress,
                                      IndexGraphStarter & graph, std::vector<Segment> & subroute,
-                                     bool guidesActive = false);
+                                     bool twoThreadsReady, bool guidesActive = false);
 
   RouterResultCode AdjustRoute(Checkpoints const & checkpoints,
                                m2::PointD const & startDirection,
@@ -208,13 +209,15 @@ private:
   }
 
   template <typename Vertex, typename Edge, typename Weight, typename AStarParams>
-  RouterResultCode FindPath(
-      AStarParams & params, std::set<NumMwmId> const & mwmIds,
-      RoutingResult<Vertex, Weight> & routingResult, WorldGraphMode mode) const
+  RouterResultCode FindPath(bool useTwoThreads, AStarParams & params,
+                            std::set<NumMwmId> const & mwmIds,
+                            RoutingResult<Vertex, Weight> & routingResult,
+                            WorldGraphMode mode) const
   {
     AStarAlgorithm<Vertex, Edge, Weight> algorithm;
     return ConvertTransitResult(
-        mwmIds, ConvertResult<Vertex, Edge, Weight>(algorithm.FindPathBidirectional(params, routingResult)));
+        mwmIds, ConvertResult<Vertex, Edge, Weight>(
+                    algorithm.FindPathBidirectional(useTwoThreads, params, routingResult)));
   }
 
   void SetupAlgorithmMode(IndexGraphStarter & starter, bool guidesActive = false) const;

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -128,7 +128,7 @@ private:
                                m2::PointD const & startDirection,
                                RouterDelegate const & delegate, Route & route);
 
-  std::unique_ptr<WorldGraph> MakeWorldGraph();
+  std::unique_ptr<WorldGraph> MakeWorldGraph(bool isTwoThreadsReady);
 
   /// \brief Removes all roads from |roads| which goes to dead ends and all road which
   /// is not good according to |worldGraph|. For car routing there are roads with hwtag nocar as well.

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -244,6 +244,8 @@ private:
   std::shared_ptr<NumMwmIds> m_numMwmIds;
   std::shared_ptr<m4::Tree<NumMwmId>> m_numMwmTree;
   std::shared_ptr<TrafficStash> m_trafficStash;
+  // Note. |m_roadGraph| contains caches inside and is not ready for multithreading.
+  // So all calls of the methods of |m_roadGraph| should be synchronized.
   FeaturesRoadGraph m_roadGraph;
 
   std::shared_ptr<EdgeEstimator> m_estimator;

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -77,6 +77,11 @@ public:
               traffic::TrafficCache const & trafficCache, DataSource & dataSource);
 
   std::unique_ptr<WorldGraph> MakeSingleMwmWorldGraph();
+  /// @todo FindBestSegments() is called for start, finish and intermediate points of the route.
+  /// On a modern mobile device this method takes 200-300ms.
+  /// The most number of routes have no intermediate points. It's worth calling this method
+  /// for start on one thread and for finish and another one. It's not difficult to implement it
+  /// based on functionality which was developed for two-thread bidirectional A*.
   bool FindBestSegments(m2::PointD const & checkpoint, m2::PointD const & direction, bool isOutgoing,
                         WorldGraph & worldGraph, std::vector<Segment> & bestSegments);
   bool FindBestEdges(m2::PointD const & checkpoint,

--- a/routing/index_router.hpp
+++ b/routing/index_router.hpp
@@ -97,8 +97,9 @@ public:
 
   void SetGuides(GuidesTracks && guides) override;
   RouterResultCode CalculateRoute(Checkpoints const & checkpoints,
-                                  m2::PointD const & startDirection, bool adjustToPrevRoute,
-                                  RouterDelegate const & delegate, Route & route) override;
+                                  m2::PointD const & startDirection, bool useTwoThreads,
+                                  bool adjustToPrevRoute, RouterDelegate const & delegate,
+                                  Route & route) override;
 
   bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction,
                                    double radius, EdgeProj & proj) override;
@@ -122,7 +123,7 @@ private:
 
   RouterResultCode DoCalculateRoute(Checkpoints const & checkpoints,
                                     m2::PointD const & startDirection,
-                                    RouterDelegate const & delegate, bool twoThreadsReady,
+                                    RouterDelegate const & delegate, bool useTwoThreads,
                                     Route & route);
   RouterResultCode CalculateSubroute(Checkpoints const & checkpoints, size_t subrouteIdx,
                                      RouterDelegate const & delegate,

--- a/routing/junction_visitor.hpp
+++ b/routing/junction_visitor.hpp
@@ -27,20 +27,21 @@ public:
       m_lastProgressPercent = progress->GetLastPercent();
   }
 
-  void operator()(Vertex const & from, Vertex const & to)
+  void operator()(Vertex const & from, Vertex const & to, bool isOutgoing)
   {
+    // @TODO This method may call from different threads. All the data should be protected.
     ++m_visitCounter;
     if (m_visitCounter % m_visitPeriod != 0)
       return;
 
-    auto const & pointFrom = m_graph.GetPoint(from, true /* front */);
+    auto const & pointFrom = m_graph.GetPoint(from, true /* front */, isOutgoing);
     m_delegate.OnPointCheck(pointFrom);
 
     auto progress = m_progress.lock();
     if (!progress)
       return;
 
-    auto const & pointTo = m_graph.GetPoint(to, true /* front */);
+    auto const & pointTo = m_graph.GetPoint(to, true /* front */, isOutgoing);
     auto const currentPercent = progress->UpdateProgress(pointFrom, pointTo);
     if (currentPercent - m_lastProgressPercent > kProgressInterval)
     {

--- a/routing/junction_visitor.hpp
+++ b/routing/junction_visitor.hpp
@@ -6,8 +6,12 @@
 
 #include "geometry/point2d.hpp"
 
+#include "base/optional_lock_guard.hpp"
+
 #include <cstdint>
 #include <memory>
+#include <mutex>
+#include <optional>
 
 namespace routing
 {
@@ -27,21 +31,25 @@ public:
       m_lastProgressPercent = progress->GetLastPercent();
   }
 
-  void operator()(Vertex const & from, Vertex const & to, bool isOutgoing)
+  void operator()(Vertex const & from, Vertex const & to, bool isOutgoing,
+                  std::optional<std::mutex> & m)
   {
-    // @TODO This method may call from different threads. All the data should be protected.
-    ++m_visitCounter;
-    if (m_visitCounter % m_visitPeriod != 0)
+    if (!IncrementCounterAndCheckPeriod(isOutgoing ? m_visitCounter : m_visitCounterBwd))
       return;
 
+    if (!m_graph.IsTwoThreadsReady())
+      CHECK(!m.has_value(), ("Graph is not ready for two threads but there's a mutex."));
+
     auto const & pointFrom = m_graph.GetPoint(from, true /* front */, isOutgoing);
+    auto const & pointTo = m_graph.GetPoint(to, true /* front */, isOutgoing);
+
+    base::OptionalLockGuard guard(m);
     m_delegate.OnPointCheck(pointFrom);
 
     auto progress = m_progress.lock();
     if (!progress)
       return;
 
-    auto const & pointTo = m_graph.GetPoint(to, true /* front */, isOutgoing);
     auto const currentPercent = progress->UpdateProgress(pointFrom, pointTo);
     if (currentPercent - m_lastProgressPercent > kProgressInterval)
     {
@@ -51,9 +59,19 @@ public:
   }
 
 private:
+  bool IncrementCounterAndCheckPeriod(uint32_t & counter)
+  {
+    ++counter;
+    if (counter % m_visitPeriod == 0)
+      return true;
+    return false;
+  }
+
   Graph & m_graph;
   RouterDelegate const & m_delegate;
+  // Only one counter is used depending on one or two thread version.
   uint32_t m_visitCounter = 0;
+  uint32_t m_visitCounterBwd = 0;
   uint32_t m_visitPeriod;
   std::weak_ptr<AStarProgress> m_progress;
   double m_lastProgressPercent = 0.0;

--- a/routing/leaps_graph.cpp
+++ b/routing/leaps_graph.cpp
@@ -10,8 +10,10 @@ namespace routing
 LeapsGraph::LeapsGraph(IndexGraphStarter & starter, MwmHierarchyHandler && hierarchyHandler)
   : m_starter(starter), m_hierarchyHandler(std::move(hierarchyHandler))
 {
-  m_startPoint = m_starter.GetPoint(m_starter.GetStartSegment(), true /* front */);
-  m_finishPoint = m_starter.GetPoint(m_starter.GetFinishSegment(), true /* front */);
+  m_startPoint =
+      m_starter.GetPoint(m_starter.GetStartSegment(), true /* front */, true /* isOutgoing */);
+  m_finishPoint =
+      m_starter.GetPoint(m_starter.GetFinishSegment(), true /* front */, true /* isOutgoing */);
   m_startSegment = m_starter.GetStartSegment();
   m_finishSegment = m_starter.GetFinishSegment();
 }
@@ -28,12 +30,13 @@ void LeapsGraph::GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & v
   GetEdgesList(vertexData.m_vertex, false /* isOutgoing */, edges);
 }
 
-RouteWeight LeapsGraph::HeuristicCostEstimate(Segment const & from, Segment const & to)
+RouteWeight LeapsGraph::HeuristicCostEstimate(Segment const & from, Segment const & to,
+                                              bool isOutgoing)
 {
   ASSERT(to == m_startSegment || to == m_finishSegment, ());
   bool const toFinish = to == m_finishSegment;
   auto const & toPoint = toFinish ? m_finishPoint : m_startPoint;
-  return m_starter.HeuristicCostEstimate(from, toPoint);
+  return m_starter.HeuristicCostEstimate(from, toPoint, isOutgoing);
 }
 
 void LeapsGraph::GetEdgesList(Segment const & segment, bool isOutgoing,
@@ -45,17 +48,17 @@ void LeapsGraph::GetEdgesList(Segment const & segment, bool isOutgoing,
   {
     CHECK(isOutgoing, ("Only forward wave of A* should get edges from start. Backward wave should "
                        "stop when first time visit the |m_startSegment|."));
-    return GetEdgesListFromStart(segment, edges);
+    return GetEdgesListFromStart(segment, isOutgoing, edges);
   }
 
   if (segment == m_finishSegment)
   {
     CHECK(!isOutgoing, ("Only backward wave of A* should get edges to finish. Forward wave should "
                         "stop when first time visit the |m_finishSegment|."));
-    return GetEdgesListToFinish(segment, edges);
+    return GetEdgesListToFinish(segment, isOutgoing, edges);
   }
 
-  if (!m_starter.IsRoutingOptionsGood(segment))
+  if (!m_starter.IsRoutingOptionsGood(segment, isOutgoing))
     return;
 
   auto & crossMwmGraph = m_starter.GetGraph().GetCrossMwmGraph();
@@ -78,7 +81,8 @@ void LeapsGraph::GetEdgesList(Segment const & segment, bool isOutgoing,
     crossMwmGraph.GetIngoingEdgeList(segment, edges);
 }
 
-void LeapsGraph::GetEdgesListFromStart(Segment const & segment, std::vector<SegmentEdge> & edges)
+void LeapsGraph::GetEdgesListFromStart(Segment const & segment, bool isOutgoing,
+                                       std::vector<SegmentEdge> & edges)
 {
   for (auto const mwmId : m_starter.GetStartEnding().m_mwmIds)
   {
@@ -86,7 +90,7 @@ void LeapsGraph::GetEdgesListFromStart(Segment const & segment, std::vector<Segm
     auto const & exits = m_starter.GetGraph().GetTransitions(mwmId, false /* isEnter */);
     for (auto const & exit : exits)
     {
-      auto const & exitFrontPoint = m_starter.GetPoint(exit, true /* front */);
+      auto const & exitFrontPoint = m_starter.GetPoint(exit, true /* front */, isOutgoing);
       auto const weight = m_starter.GetGraph().CalcLeapWeight(m_startPoint, exitFrontPoint);
 
       edges.emplace_back(exit, weight);
@@ -94,7 +98,8 @@ void LeapsGraph::GetEdgesListFromStart(Segment const & segment, std::vector<Segm
   }
 }
 
-void LeapsGraph::GetEdgesListToFinish(Segment const & segment, std::vector<SegmentEdge> & edges)
+void LeapsGraph::GetEdgesListToFinish(Segment const & segment, bool isOutgoing,
+                                      std::vector<SegmentEdge> & edges)
 {
   for (auto const mwmId : m_starter.GetFinishEnding().m_mwmIds)
   {
@@ -102,7 +107,7 @@ void LeapsGraph::GetEdgesListToFinish(Segment const & segment, std::vector<Segme
     auto const & enters = m_starter.GetGraph().GetTransitions(mwmId, true /* isEnter */);
     for (auto const & enter : enters)
     {
-      auto const & enterFrontPoint = m_starter.GetPoint(enter, true /* front */);
+      auto const & enterFrontPoint = m_starter.GetPoint(enter, true /* front */, isOutgoing);
       auto const weight = m_starter.GetGraph().CalcLeapWeight(enterFrontPoint, m_finishPoint);
 
       edges.emplace_back(enter, weight);
@@ -110,9 +115,9 @@ void LeapsGraph::GetEdgesListToFinish(Segment const & segment, std::vector<Segme
   }
 }
 
-ms::LatLon const & LeapsGraph::GetPoint(Segment const & segment, bool front) const
+ms::LatLon const & LeapsGraph::GetPoint(Segment const & segment, bool front, bool isOutgoing) const
 {
-  return m_starter.GetPoint(segment, front);
+  return m_starter.GetPoint(segment, front, isOutgoing);
 }
 
 Segment const & LeapsGraph::GetStartSegment() const

--- a/routing/leaps_graph.hpp
+++ b/routing/leaps_graph.hpp
@@ -24,19 +24,21 @@ public:
                             std::vector<SegmentEdge> & edges) override;
   void GetIngoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
                            std::vector<SegmentEdge> & edges) override;
-  RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to) override;
+  RouteWeight HeuristicCostEstimate(Segment const & from, Segment const & to,
+                                    bool isOutgoing) override;
   RouteWeight GetAStarWeightEpsilon() override;
   // @}
 
   Segment const & GetStartSegment() const;
   Segment const & GetFinishSegment() const;
-  ms::LatLon const & GetPoint(Segment const & segment, bool front) const;
+  ms::LatLon const & GetPoint(Segment const & segment, bool front, bool isOutgoing) const;
 
 private:
   void GetEdgesList(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);
 
-  void GetEdgesListFromStart(Segment const & segment, std::vector<SegmentEdge> & edges);
-  void GetEdgesListToFinish(Segment const & segment, std::vector<SegmentEdge> & edges);
+  void GetEdgesListFromStart(Segment const & segment, bool isOutgoing,
+                             std::vector<SegmentEdge> & edges);
+  void GetEdgesListToFinish(Segment const & segment, bool isOutgoing, std::vector<SegmentEdge> & edges);
 
   ms::LatLon m_startPoint;
   ms::LatLon m_finishPoint;

--- a/routing/leaps_postprocessor.cpp
+++ b/routing/leaps_postprocessor.cpp
@@ -103,7 +103,8 @@ void LeapsPostProcessor::Init()
   for (size_t i = 1; i < m_path.size(); ++i)
   {
     auto const & segment = m_path[i];
-    m_prefixSumETA[i] = m_prefixSumETA[i - 1] + m_starter.CalculateETAWithoutPenalty(segment);
+    m_prefixSumETA[i] = m_prefixSumETA[i - 1] +
+                        m_starter.CalculateETAWithoutPenalty(segment, true /* isOutgoing */);
 
     CHECK_EQUAL(m_segmentToIndex.count(segment), 0, ());
     m_segmentToIndex[segment] = i;
@@ -146,7 +147,8 @@ auto LeapsPostProcessor::CalculateIntervalsToRelax() -> std::set<PathInterval, P
   {
     std::map<Segment, SegmentData> segmentsData;
     auto const & segment = m_path[right];
-    segmentsData.emplace(segment, SegmentData(0, m_starter.CalculateETAWithoutPenalty(segment)));
+    segmentsData.emplace(segment, SegmentData(0, m_starter.CalculateETAWithoutPenalty(
+                                                     segment, true /* isOutgoing */)));
 
     FillIngoingPaths(segment, segmentsData);
 
@@ -192,7 +194,8 @@ void LeapsPostProcessor::FillIngoingPaths(
 
               auto & current = segmentsData[state.m_vertex];
               current.m_summaryETA =
-                  parent.m_summaryETA + m_starter.CalculateETAWithoutPenalty(state.m_vertex);
+                  parent.m_summaryETA +
+                  m_starter.CalculateETAWithoutPenalty(state.m_vertex, true /* isOutgoing */);
 
               current.m_steps = parent.m_steps + 1;
 

--- a/routing/restriction_loader.cpp
+++ b/routing/restriction_loader.cpp
@@ -162,7 +162,8 @@ void ConvertRestrictionsOnlyUTurnToNo(IndexGraph & graph,
     if (!graph.IsRoad(featureId))
       continue;
 
-    uint32_t const n = graph.GetGeometry().GetRoad(featureId).GetPointsCount();
+    // @TODO isOutgoing should be passed from IndexGraphLoaderImpl::GetIndexGraph()
+    uint32_t const n = graph.GetGeometry().GetRoad(featureId, true /* isOutgoing */).GetPointsCount();
     RoadJointIds const & joints = graph.GetRoad(uTurnRestriction.m_featureId);
     Joint::Id const joint = uTurnRestriction.m_viaIsFirstPoint ? joints.GetJointId(0)
                                                                : joints.GetJointId(n - 1);

--- a/routing/restriction_loader.cpp
+++ b/routing/restriction_loader.cpp
@@ -162,7 +162,15 @@ void ConvertRestrictionsOnlyUTurnToNo(IndexGraph & graph,
     if (!graph.IsRoad(featureId))
       continue;
 
-    // @TODO isOutgoing should be passed from IndexGraphLoaderImpl::GetIndexGraph()
+    // On the one hand to pass |isOutgoing| param to this method is quite difficult. To do that
+    // should be modified: AStarGraph::AreWavesConnectible() and methods in derived classes,
+    // two methods WorldGraph::AreWavesConnectible() and methods in derived classes and so on.
+    // About 110 lines should be modified.
+    // On the other hand loading ConvertRestrictionsOnlyUTurnToNo() is called only from
+    // RestrictionLoader constructor and this operation is planned to be implemented
+    // under mutex in case of two threaded bidirectional A star.
+    // To prevent inflating function signatures by adding |isOutgoing| parameter
+    // it should be hardcode as true here.
     uint32_t const n = graph.GetGeometry().GetRoad(featureId, true /* isOutgoing */).GetPointsCount();
     RoadJointIds const & joints = graph.GetRoad(uTurnRestriction.m_featureId);
     Joint::Id const joint = uTurnRestriction.m_viaIsFirstPoint ? joints.GetJointId(0)

--- a/routing/router.hpp
+++ b/routing/router.hpp
@@ -79,8 +79,9 @@ public:
   /// @return ResultCode error code or NoError if route was initialised
   /// @see Cancellable
   virtual RouterResultCode CalculateRoute(Checkpoints const & checkpoints,
-                                          m2::PointD const & startDirection, bool adjust,
-                                          RouterDelegate const & delegate, Route & route) = 0;
+                                          m2::PointD const & startDirection, bool useTwoThreads,
+                                          bool adjust, RouterDelegate const & delegate,
+                                          Route & route) = 0;
 
   virtual bool FindClosestProjectionToRoad(m2::PointD const & point, m2::PointD const & direction,
                                            double radius, EdgeProj & proj) = 0;

--- a/routing/routes_builder/routes_builder.cpp
+++ b/routing/routes_builder/routes_builder.cpp
@@ -302,7 +302,8 @@ RoutesBuilder::Processor::operator()(Params const & params)
     m_delegate->SetTimeout(params.m_timeoutSeconds);
     base::Timer timer;
     resultCode = m_router->CalculateRoute(params.m_checkpoints, m2::PointD::Zero(),
-                                          false /* adjustToPrevRoute */, *m_delegate, route);
+                                          false /* useTwoThreads */, false /* adjustToPrevRoute */,
+                                          *m_delegate, route);
 
     if (resultCode != RouterResultCode::NoError)
       break;

--- a/routing/routing_benchmarks/helpers.cpp
+++ b/routing/routing_benchmarks/helpers.cpp
@@ -154,9 +154,9 @@ void TestRouter(routing::IRouter & router, m2::PointD const & startPos,
   routing::RouterDelegate delegate;
   LOG(LINFO, ("Calculating routing ...", router.GetName()));
   base::Timer timer;
-  auto const resultCode = router.CalculateRoute(routing::Checkpoints(startPos, finalPos),
-                                                m2::PointD::Zero() /* startDirection */,
-                                                false /* adjust */, delegate, route);
+  auto const resultCode = router.CalculateRoute(
+      routing::Checkpoints(startPos, finalPos), m2::PointD::Zero() /* startDirection */,
+      false /* useTwoThreads */, false /* adjust */, delegate, route);
   double const elapsedSec = timer.ElapsedSeconds();
   TEST_EQUAL(routing::RouterResultCode::NoError, resultCode, ());
   TEST(route.IsValid(), ());

--- a/routing/routing_helpers.cpp
+++ b/routing/routing_helpers.cpp
@@ -245,19 +245,19 @@ bool CheckGraphConnectivity(Segment const & start, bool isOutgoing, bool useRout
 
 AStarLengthChecker::AStarLengthChecker(IndexGraphStarter & starter) : m_starter(starter) {}
 
-bool AStarLengthChecker::operator()(RouteWeight const & weight) const
+bool AStarLengthChecker::operator()(RouteWeight const & weight, bool isOutgoing) const
 {
-  return m_starter.CheckLength(weight);
+  return m_starter.CheckLength(weight, isOutgoing);
 }
 
 // AdjustLengthChecker -----------------------------------------------------------------------------
 
 AdjustLengthChecker::AdjustLengthChecker(IndexGraphStarter & starter) : m_starter(starter) {}
 
-bool AdjustLengthChecker::operator()(RouteWeight const & weight) const
+bool AdjustLengthChecker::operator()(RouteWeight const & weight, bool isOutgoing) const
 {
   // Limit of adjust in seconds.
   double constexpr kAdjustLimitSec = 5 * 60;
-  return weight <= RouteWeight(kAdjustLimitSec) && m_starter.CheckLength(weight);
+  return weight <= RouteWeight(kAdjustLimitSec) && m_starter.CheckLength(weight, isOutgoing);
 }
 }  // namespace routing

--- a/routing/routing_helpers.hpp
+++ b/routing/routing_helpers.hpp
@@ -84,14 +84,14 @@ bool CheckGraphConnectivity(Segment const & start, bool isOutgoing,
 struct AStarLengthChecker
 {
   explicit AStarLengthChecker(IndexGraphStarter & starter);
-  bool operator()(RouteWeight const & weight) const;
+  bool operator()(RouteWeight const & weight, bool isOutgoing) const;
   IndexGraphStarter & m_starter;
 };
 
 struct AdjustLengthChecker
 {
   explicit AdjustLengthChecker(IndexGraphStarter & starter);
-  bool operator()(RouteWeight const & weight) const;
+  bool operator()(RouteWeight const & weight, bool isOutgoing) const;
   IndexGraphStarter & m_starter;
 };
 }  // namespace routing

--- a/routing/routing_integration_tests/get_altitude_test.cpp
+++ b/routing/routing_integration_tests/get_altitude_test.cpp
@@ -44,8 +44,8 @@ void TestAltitudeOfAllMwmFeatures(string const & countryId,
   TEST_EQUAL(regResult.second, MwmSet::RegResult::Success, ());
   TEST(regResult.first.IsAlive(), ());
 
-  unique_ptr<AltitudeLoader> altitudeLoader =
-      make_unique<AltitudeLoader>(dataSource, regResult.first /* mwmId */);
+  unique_ptr<AltitudeLoader> altitudeLoader = make_unique<AltitudeLoader>(
+      dataSource, regResult.first /* mwmId */, false /* twoThreadsReady */);
 
   ForEachFeature(country.GetPath(MapFileType::Map), [&](FeatureType & f, uint32_t const & id) {
     if (!routing::IsRoad(TypesHolder(f)))
@@ -56,7 +56,8 @@ void TestAltitudeOfAllMwmFeatures(string const & countryId,
     if (pointsCount == 0)
       return;
 
-    geometry::Altitudes altitudes = altitudeLoader->GetAltitudes(id, pointsCount);
+    geometry::Altitudes altitudes =
+        altitudeLoader->GetAltitudes(id, pointsCount, true /* isOutgoing */);
     TEST(!altitudes.empty(),
          ("Empty altitude vector. MWM:", countryId, ", feature id:", id, ", altitudes:", altitudes));
 

--- a/routing/routing_integration_tests/pedestrian_route_test.cpp
+++ b/routing/routing_integration_tests/pedestrian_route_test.cpp
@@ -581,3 +581,13 @@ UNIT_TEST(NoTurnOnForkingRoad2)
 
   TEST_EQUAL(t[0].m_pedestrianTurn, PedestrianDirection::TurnRight, ());
 }
+
+// Test on two threads A* bidirectional routing.
+UNIT_TEST(RussiaMoscowTarusaTwoThreads)
+{
+  integration::CalculateRouteAndTestRouteLength(
+      integration::GetVehicleComponents(VehicleType::Pedestrian),
+      mercator::FromLatLon(55.85779, 37.40948), {0.0, 0.0},
+      mercator::FromLatLon(54.71961, 37.19449), 162575.0, 0.07 /* relativeError  */,
+      true /* useTwoThreads */);
+}

--- a/routing/routing_integration_tests/route_test.cpp
+++ b/routing/routing_integration_tests/route_test.cpp
@@ -572,4 +572,15 @@ namespace
         integration::GetVehicleComponents(VehicleType::Car),
         mercator::FromLatLon(55.31103, 38.80954), {0., 0.}, mercator::FromLatLon(55.31155, 38.8217), 2489.8);
   }
+
+  // Test on two threads A* bidirectional routing.
+  UNIT_TEST(RussiaMoscowStStPetersburgTwoThreads)
+  {
+    auto & vehicleComponents = integration::GetVehicleComponents(VehicleType::Car);
+
+    integration::CalculateRouteAndTestRouteLength(
+        vehicleComponents, mercator::FromLatLon(55.74942, 37.62118), {0.0, 0.0},
+        mercator::FromLatLon(59.9394, 30.31492), 706503.0, 0.07 /* relativeError  */,
+        true /* useTwoThreads */);
+  }
 }  // namespace

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -153,12 +153,13 @@ IRouterComponents & GetVehicleComponents(VehicleType vehicleType)
 
 TRouteResult CalculateRoute(IRouterComponents const & routerComponents,
                             m2::PointD const & startPoint, m2::PointD const & startDirection,
-                            m2::PointD const & finalPoint)
+                            m2::PointD const & finalPoint, bool useTwoThreads /* = false */)
 {
   RouterDelegate delegate;
   shared_ptr<Route> route = make_shared<Route>("mapsme", 0 /* route id */);
   RouterResultCode result = routerComponents.GetRouter().CalculateRoute(
-      Checkpoints(startPoint, finalPoint), startDirection, false /* adjust */, delegate, *route);
+      Checkpoints(startPoint, finalPoint), startDirection, useTwoThreads, false /* adjust */,
+      delegate, *route);
   ASSERT(route, ());
   routerComponents.GetRouter().SetGuides({});
   return TRouteResult(route, result);
@@ -171,7 +172,8 @@ TRouteResult CalculateRoute(IRouterComponents const & routerComponents,
   shared_ptr<Route> route = make_shared<Route>("mapsme", 0 /* route id */);
   routerComponents.GetRouter().SetGuides(move(guides));
   RouterResultCode result = routerComponents.GetRouter().CalculateRoute(
-      checkpoints, m2::PointD::Zero() /* startDirection */, false /* adjust */, delegate, *route);
+      checkpoints, m2::PointD::Zero() /* startDirection */, false /* useTwoThreads */,
+      false /* adjust */, delegate, *route);
   ASSERT(route, ());
   routerComponents.GetRouter().SetGuides({});
   return TRouteResult(route, result);

--- a/routing/routing_integration_tests/routing_test_tools.cpp
+++ b/routing/routing_integration_tests/routing_test_tools.cpp
@@ -236,10 +236,10 @@ void CalculateRouteAndTestRouteLength(IRouterComponents const & routerComponents
                                       m2::PointD const & startPoint,
                                       m2::PointD const & startDirection,
                                       m2::PointD const & finalPoint, double expectedRouteMeters,
-                                      double relativeError /* = 0.07 */)
+                                      double relativeError /* = 0.07 */, bool useTwoThreads /* = false */)
 {
   TRouteResult routeResult =
-      CalculateRoute(routerComponents, startPoint, startDirection, finalPoint);
+      CalculateRoute(routerComponents, startPoint, startDirection, finalPoint, useTwoThreads);
   RouterResultCode const result = routeResult.second;
   TEST_EQUAL(result, RouterResultCode::NoError, ());
   CHECK(routeResult.first, ());

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -129,7 +129,7 @@ void CalculateRouteAndTestRouteLength(IRouterComponents const & routerComponents
                                       m2::PointD const & startPoint,
                                       m2::PointD const & startDirection,
                                       m2::PointD const & finalPoint, double expectedRouteMeters,
-                                      double relativeError = 0.07);
+                                      double relativeError = 0.07, bool useTwoThreads = false);
 
 void CalculateRouteAndTestRouteTime(IRouterComponents const & routerComponents,
                                     m2::PointD const & startPoint,

--- a/routing/routing_integration_tests/routing_test_tools.hpp
+++ b/routing/routing_integration_tests/routing_test_tools.hpp
@@ -108,7 +108,7 @@ IRouterComponents & GetVehicleComponents(VehicleType vehicleType);
 
 TRouteResult CalculateRoute(IRouterComponents const & routerComponents,
                             m2::PointD const & startPoint, m2::PointD const & startDirection,
-                            m2::PointD const & finalPoint);
+                            m2::PointD const & finalPoint, bool useTwoThreads = false);
 
 TRouteResult CalculateRoute(IRouterComponents const & routerComponents,
                             Checkpoints const & checkpoints, GuidesTracks && guides);

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -63,7 +63,7 @@ UNIT_TEST(AStarAlgorithm_CheckLength)
   graph.AddEdge(2, 4, 10);
   graph.AddEdge(3, 4, 3);
 
-  auto checkLength = [](double weight) { return weight < 23; };
+  auto checkLength = [](double weight, bool /* isOutgoing */) { return weight < 23; };
   Algorithm algo;
   Algorithm::ParamsForTests<decltype(checkLength)> params(
       graph, 0u /* startVertex */, 4u /* finishVertex */, nullptr /* prevRoute */,
@@ -94,7 +94,7 @@ UNIT_TEST(AdjustRoute)
   // Each edge contains {vertexId, weight}.
   vector<SimpleEdge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
-  auto checkLength = [](double weight) { return weight <= 1.0; };
+  auto checkLength = [](double weight, bool /* isOutgoing */) { return weight <= 1.0; };
   Algorithm algo;
   Algorithm::ParamsForTests<decltype(checkLength)> params(
       graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute, move(checkLength));
@@ -118,7 +118,7 @@ UNIT_TEST(AdjustRouteNoPath)
   // Each edge contains {vertexId, weight}.
   vector<SimpleEdge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
-  auto checkLength = [](double weight) { return weight <= 1.0; };
+  auto checkLength = [](double weight, bool /* isOutgoing */) { return weight <= 1.0; };
   Algorithm algo;
   Algorithm::ParamsForTests<decltype(checkLength)> params(graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute,
                                      move(checkLength));
@@ -141,7 +141,7 @@ UNIT_TEST(AdjustRouteOutOfLimit)
   // Each edge contains {vertexId, weight}.
   vector<SimpleEdge> const prevRoute = {{0, 0}, {1, 1}, {2, 1}, {3, 1}, {4, 1}, {5, 1}};
 
-  auto checkLength = [](double weight) { return weight <= 1.0; };
+  auto checkLength = [](double weight, bool /* isOutgoing */) { return weight <= 1.0; };
   Algorithm algo;
   Algorithm::ParamsForTests<decltype(checkLength)> params(
       graph, 6 /* startVertex */, {} /* finishVertex */, &prevRoute, move(checkLength));

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -31,7 +31,8 @@ void TestAStar(UndirectedGraph & graph, vector<unsigned> const & expectedRoute, 
   TEST_ALMOST_EQUAL_ULPS(expectedDistance, actualRoute.m_distance, ());
 
   actualRoute.m_path.clear();
-  TEST_EQUAL(Algorithm::Result::OK, algo.FindPathBidirectional(params, actualRoute), ());
+  TEST_EQUAL(Algorithm::Result::OK,
+             algo.FindPathBidirectional(false /* useTwoThreads */, params, actualRoute), ());
   TEST_EQUAL(expectedRoute, actualRoute.m_path, ());
   TEST_ALMOST_EQUAL_ULPS(expectedDistance, actualRoute.m_distance, ());
 }
@@ -75,7 +76,7 @@ UNIT_TEST(AStarAlgorithm_CheckLength)
   TEST_EQUAL(result, Algorithm::Result::NoPath, ());
 
   routingResult = {};
-  result = algo.FindPathBidirectional(params, routingResult);
+  result = algo.FindPathBidirectional(false /* useTwoThreads */, params, routingResult);
   // Best route weight is 23 so we expect to find no route with restriction |weight < 23|.
   TEST_EQUAL(result, Algorithm::Result::NoPath, ());
 }

--- a/routing/routing_tests/astar_algorithm_test.cpp
+++ b/routing/routing_tests/astar_algorithm_test.cpp
@@ -32,7 +32,7 @@ void TestAStar(UndirectedGraph & graph, vector<unsigned> const & expectedRoute, 
 
   actualRoute.m_path.clear();
   TEST_EQUAL(Algorithm::Result::OK,
-             algo.FindPathBidirectional(false /* useTwoThreads */, params, actualRoute), ());
+             algo.FindPathBidirectional(params, actualRoute), ());
   TEST_EQUAL(expectedRoute, actualRoute.m_path, ());
   TEST_ALMOST_EQUAL_ULPS(expectedDistance, actualRoute.m_distance, ());
 }
@@ -76,7 +76,7 @@ UNIT_TEST(AStarAlgorithm_CheckLength)
   TEST_EQUAL(result, Algorithm::Result::NoPath, ());
 
   routingResult = {};
-  result = algo.FindPathBidirectional(false /* useTwoThreads */, params, routingResult);
+  result = algo.FindPathBidirectional(params, routingResult);
   // Best route weight is 23 so we expect to find no route with restriction |weight < 23|.
   TEST_EQUAL(result, Algorithm::Result::NoPath, ());
 }

--- a/routing/routing_tests/async_router_test.cpp
+++ b/routing/routing_tests/async_router_test.cpp
@@ -37,9 +37,10 @@ public:
   // IRouter overrides:
   string GetName() const override { return "Dummy"; }
   void SetGuides(GuidesTracks && /* guides */) override {}
-  RouterResultCode CalculateRoute(Checkpoints const & checkpoints, m2::PointD const & startDirection,
-                            bool adjustToPrevRoute, RouterDelegate const & delegate,
-                            Route & route) override
+  RouterResultCode CalculateRoute(Checkpoints const & checkpoints,
+                                  m2::PointD const & startDirection, bool useTwoThreads,
+                                  bool adjustToPrevRoute, RouterDelegate const & delegate,
+                                  Route & route) override
   {
     route = Route("dummy", checkpoints.GetPoints().cbegin(), checkpoints.GetPoints().cend(),
                   0 /* route id */);

--- a/routing/routing_tests/index_graph_test.cpp
+++ b/routing/routing_tests/index_graph_test.cpp
@@ -81,7 +81,8 @@ void TestRoute(FakeEnding const & start, FakeEnding const & finish, size_t expec
 void TestEdges(IndexGraph & graph, Segment const & segment, vector<Segment> const & expectedTargets,
                bool isOutgoing)
 {
-  ASSERT(segment.IsForward() || !graph.GetGeometry().GetRoad(segment.GetFeatureId()).IsOneWay(),
+  ASSERT(segment.IsForward() ||
+             !graph.GetGeometry().GetRoad(segment.GetFeatureId(), true /* isOutgoing */).IsOneWay(),
          ());
 
   vector<SegmentEdge> edges;

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -519,13 +519,13 @@ void TestRouteGeometry(IndexGraphStarter & starter,
 
   for (auto const & routeSeg : routeSegs)
   {
-    auto const & ll = starter.GetPoint(routeSeg, false /* front */);
+    auto const & ll = starter.GetPoint(routeSeg, false /* front */, true /* isOutgoing */);
     // Note. In case of A* router all internal points of route are duplicated.
     // So it's necessary to exclude the duplicates.
     pushPoint(ll);
   }
 
-  pushPoint(starter.GetPoint(routeSegs.back(), false /* front */));
+  pushPoint(starter.GetPoint(routeSegs.back(), false /* front */, true /* isOutgoing */));
   TEST_EQUAL(geom.size(), expectedRouteGeom.size(), ("geom:", geom, "expectedRouteGeom:", expectedRouteGeom));
   for (size_t i = 0; i < geom.size(); ++i)
   {
@@ -583,8 +583,8 @@ void TestRestrictions(double expectedLength,
   double length = 0.0;
   for (auto const & segment : segments)
   {
-    auto const back = mercator::FromLatLon(starter.GetPoint(segment, false /* front */));
-    auto const front = mercator::FromLatLon(starter.GetPoint(segment, true /* front */));
+    auto const back = mercator::FromLatLon(starter.GetPoint(segment, false /* front */, true /* isOutgoing */));
+    auto const front = mercator::FromLatLon(starter.GetPoint(segment, true /* front */, true /* isOutgoing */));
 
     length += back.Length(front);
   }

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -91,7 +91,8 @@ void NoUTurnRestrictionTest::TestRouteGeom(Segment const & start, Segment const 
   for (size_t i = 0; i < routingResult.m_path.size(); ++i)
   {
     static auto constexpr kEps = 1e-3;
-    auto const point = m_graph->GetWorldGraph().GetPoint(routingResult.m_path[i], true /* forward */);
+    auto const point = m_graph->GetWorldGraph().GetPoint(routingResult.m_path[i], true /* front */,
+                                                         true /* isOutgoing */);
     if (!base::AlmostEqualAbs(mercator::FromLatLon(point), expectedRouteGeom[i], kEps))
     {
       TEST(false, ("Coords missmated at index:", i, "expected:", expectedRouteGeom[i],

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -8,7 +8,6 @@
 
 #include "transit/transit_version.hpp"
 
-#include "base/assert.hpp"
 #include "base/math.hpp"
 
 #include <unordered_map>

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -101,8 +101,10 @@ void NoUTurnRestrictionTest::TestRouteGeom(Segment const & start, Segment const 
 }
 
 // ZeroGeometryLoader ------------------------------------------------------------------------------
-void ZeroGeometryLoader::Load(uint32_t /* featureId */, routing::RoadGeometry & road)
+void ZeroGeometryLoader::Load(uint32_t /* featureId */, routing::RoadGeometry & road,
+                              bool isOutgoing)
 {
+  CHECK(isOutgoing, ("ZeroGeometryLoader() is not ready for two threads feature parsing."));
   // Any valid road will do.
   auto const points = routing::RoadGeometry::Points({{0.0, 0.0}, {0.0, 1.0}});
   road = RoadGeometry(true /* oneWay */, 1.0 /* weightSpeedKMpH */, 1.0 /* etaSpeedKMpH */, points);

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -85,7 +85,7 @@ void NoUTurnRestrictionTest::TestRouteGeom(Segment const & start, Segment const 
 
   RoutingResult<Segment, RouteWeight> routingResult;
   auto const resultCode =
-      algorithm.FindPathBidirectional(false /* useTwoThreads */, params, routingResult);
+      algorithm.FindPathBidirectional(params, routingResult);
 
   TEST_EQUAL(resultCode, expectedRouteResult, ());
   for (size_t i = 0; i < routingResult.m_path.size(); ++i)
@@ -279,7 +279,7 @@ bool TestIndexGraphTopology::FindPath(Vertex start, Vertex finish, double & path
                                                   nullptr /* prevRoute */);
   RoutingResult<Segment, RouteWeight> routingResult;
   auto const resultCode =
-      algorithm.FindPathBidirectional(false /* useTwoThreads */, params, routingResult);
+      algorithm.FindPathBidirectional(params, routingResult);
 
   // Check unidirectional AStar returns same result.
   {
@@ -485,7 +485,7 @@ AlgorithmForWorldGraph::Result CalculateRoute(IndexGraphStarter & starter, vecto
       AStarLengthChecker(starter));
 
   auto const resultCode =
-      algorithm.FindPathBidirectional(false /* useTwoThreads */, params, routingResult);
+      algorithm.FindPathBidirectional(params, routingResult);
 
   timeSec = routingResult.m_distance.GetWeight();
   roadPoints = routingResult.m_path;

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -420,7 +420,8 @@ unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoade
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));
   return make_unique<SingleVehicleWorldGraph>(nullptr /* crossMwmGraph */, move(indexLoader),
-                                              estimator, MwmHierarchyHandler(nullptr, nullptr));
+                                              estimator, false /* twoThreadsReady */,
+                                              MwmHierarchyHandler(nullptr, nullptr));
 }
 
 unique_ptr<IndexGraph> BuildIndexGraph(unique_ptr<TestGeometryLoader> geometryLoader,
@@ -442,7 +443,8 @@ unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<ZeroGeometryLoade
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));
   return make_unique<SingleVehicleWorldGraph>(nullptr /* crossMwmGraph */, move(indexLoader),
-                                              estimator, MwmHierarchyHandler(nullptr, nullptr));
+                                              estimator, false /* twoThreadsReady */,
+                                              MwmHierarchyHandler(nullptr, nullptr));
 }
 
 unique_ptr<TransitWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> geometryLoader,
@@ -620,7 +622,7 @@ unique_ptr<IndexGraphStarter> MakeStarter(FakeEnding const & start, FakeEnding c
                                           WorldGraph & graph)
 {
   return make_unique<IndexGraphStarter>(start, finish, 0 /* fakeNumerationStart */,
-                                        false /* strictForward */, false /* twoThreadsReady */, graph);
+                                        false /* strictForward */, graph);
 }
 
 time_t GetUnixtimeByDate(uint16_t year, Month month, uint8_t monthDay, uint8_t hours,

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -620,7 +620,7 @@ unique_ptr<IndexGraphStarter> MakeStarter(FakeEnding const & start, FakeEnding c
                                           WorldGraph & graph)
 {
   return make_unique<IndexGraphStarter>(start, finish, 0 /* fakeNumerationStart */,
-                                        false /* strictForward */, graph);
+                                        false /* strictForward */, false /* twoThreadsReady */, graph);
 }
 
 time_t GetUnixtimeByDate(uint16_t year, Month month, uint8_t monthDay, uint8_t hours,

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -438,7 +438,7 @@ unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<ZeroGeometryLoade
                                                     vector<Joint> const & joints)
 {
   auto graph = make_unique<IndexGraph>(make_shared<Geometry>(move(geometryLoader)), estimator);
-  
+
   graph->Import(joints);
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -420,7 +420,7 @@ unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoade
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));
   return make_unique<SingleVehicleWorldGraph>(nullptr /* crossMwmGraph */, move(indexLoader),
-                                              estimator, false /* twoThreadsReady */,
+                                              estimator,
                                               MwmHierarchyHandler(nullptr, nullptr));
 }
 
@@ -443,8 +443,7 @@ unique_ptr<SingleVehicleWorldGraph> BuildWorldGraph(unique_ptr<ZeroGeometryLoade
   auto indexLoader = make_unique<TestIndexGraphLoader>();
   indexLoader->AddGraph(kTestNumMwmId, move(graph));
   return make_unique<SingleVehicleWorldGraph>(nullptr /* crossMwmGraph */, move(indexLoader),
-                                              estimator, false /* twoThreadsReady */,
-                                              MwmHierarchyHandler(nullptr, nullptr));
+                                              estimator, MwmHierarchyHandler(nullptr, nullptr));
 }
 
 unique_ptr<TransitWorldGraph> BuildWorldGraph(unique_ptr<TestGeometryLoader> geometryLoader,

--- a/routing/routing_tests/index_graph_tools.cpp
+++ b/routing/routing_tests/index_graph_tools.cpp
@@ -84,7 +84,8 @@ void NoUTurnRestrictionTest::TestRouteGeom(Segment const & start, Segment const 
                                                   nullptr /* prevRoute */);
 
   RoutingResult<Segment, RouteWeight> routingResult;
-  auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);
+  auto const resultCode =
+      algorithm.FindPathBidirectional(false /* useTwoThreads */, params, routingResult);
 
   TEST_EQUAL(resultCode, expectedRouteResult, ());
   for (size_t i = 0; i < routingResult.m_path.size(); ++i)
@@ -277,7 +278,8 @@ bool TestIndexGraphTopology::FindPath(Vertex start, Vertex finish, double & path
   AlgorithmForWorldGraph::ParamsForTests<> params(graphForAStar, startSegment, finishSegment,
                                                   nullptr /* prevRoute */);
   RoutingResult<Segment, RouteWeight> routingResult;
-  auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);
+  auto const resultCode =
+      algorithm.FindPathBidirectional(false /* useTwoThreads */, params, routingResult);
 
   // Check unidirectional AStar returns same result.
   {
@@ -482,7 +484,8 @@ AlgorithmForWorldGraph::Result CalculateRoute(IndexGraphStarter & starter, vecto
       starter, starter.GetStartSegment(), starter.GetFinishSegment(), nullptr /* prevRoute */,
       AStarLengthChecker(starter));
 
-  auto const resultCode = algorithm.FindPathBidirectional(params, routingResult);
+  auto const resultCode =
+      algorithm.FindPathBidirectional(false /* useTwoThreads */, params, routingResult);
 
   timeSec = routingResult.m_distance.GetWeight();
   roadPoints = routingResult.m_path;

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -28,6 +28,8 @@
 
 #include "geometry/point2d.hpp"
 
+#include "base/assert.hpp"
+
 #include <algorithm>
 #include <cstdint>
 #include <ctime>
@@ -50,7 +52,11 @@ using AlgorithmForWorldGraph = AStarAlgorithm<Segment, SegmentEdge, RouteWeight>
 class WorldGraphForAStar : public AStarGraph<Segment, SegmentEdge, RouteWeight>
 {
 public:
-  explicit WorldGraphForAStar(std::unique_ptr<SingleVehicleWorldGraph> graph) : m_graph(std::move(graph)) {}
+  explicit WorldGraphForAStar(std::unique_ptr<SingleVehicleWorldGraph> graph)
+    : m_graph(std::move(graph))
+  {
+    CHECK(!GetMultithreadingReady(), ());
+  }
   ~WorldGraphForAStar() override = default;
 
   // AStarGraph overrides:

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -55,10 +55,10 @@ public:
 
   // AStarGraph overrides:
   // @{
-  Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to) override
+  Weight HeuristicCostEstimate(Vertex const & from, Vertex const & to, bool isOutgoing) override
   {
-    return m_graph->HeuristicCostEstimate(m_graph->GetPoint(from, true /* front */),
-                                          m_graph->GetPoint(to, true /* front */));
+    return m_graph->HeuristicCostEstimate(m_graph->GetPoint(from, true /* front */, isOutgoing),
+                                          m_graph->GetPoint(to, true /* front */, isOutgoing));
   }
 
   void GetOutgoingEdgesList(astar::VertexData<Vertex, RouteWeight> const & vertexData,

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -125,7 +125,7 @@ public:
   // GeometryLoader overrides:
   ~ZeroGeometryLoader() override = default;
 
-  void Load(uint32_t featureId, routing::RoadGeometry & road) override;
+  void Load(uint32_t featureId, routing::RoadGeometry & road, bool isOutgoing) override;
 };
 
 class TestIndexGraphLoader final : public IndexGraphLoader

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -143,6 +143,8 @@ public:
 
   void Clear() override;
 
+  bool IsTwoThreadsReady() const override { return false; }
+
   void AddGraph(NumMwmId mwmId, std::unique_ptr<IndexGraph> graph);
 
 private:

--- a/routing/routing_tests/index_graph_tools.hpp
+++ b/routing/routing_tests/index_graph_tools.hpp
@@ -55,7 +55,7 @@ public:
   explicit WorldGraphForAStar(std::unique_ptr<SingleVehicleWorldGraph> graph)
     : m_graph(std::move(graph))
   {
-    CHECK(!GetMultithreadingReady(), ());
+    CHECK(!IsTwoThreadsReady(), ());
   }
   ~WorldGraphForAStar() override = default;
 

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -16,6 +16,11 @@
 
 namespace routing_test
 {
+UndirectedGraph::UndirectedGraph()
+{
+  CHECK(!GetMultithreadingReady(), ());
+}
+
 void UndirectedGraph::AddEdge(Vertex u, Vertex v, Weight w)
 {
   m_adjs[u].emplace_back(v, w);
@@ -115,7 +120,9 @@ public:
 
   explicit RoadGraph(IRoadGraph const & roadGraph)
     : m_roadGraph(roadGraph), m_maxSpeedMPS(KMPH2MPS(roadGraph.GetMaxSpeedKMpH()))
-  {}
+  {
+    CHECK(!GetMultithreadingReady(), ());
+  }
 
   void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
                             std::vector<Edge> & adj) override

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -45,7 +45,7 @@ void UndirectedGraph::GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> con
   GetEdgesList(vertexData.m_vertex, true /* isOutgoing */, adj);
 }
 
-double UndirectedGraph::HeuristicCostEstimate(Vertex const & v, Vertex const & w)
+double UndirectedGraph::HeuristicCostEstimate(Vertex const & v, Vertex const & w, bool isOutgoing)
 {
   return 0.0;
 }
@@ -157,7 +157,7 @@ public:
     }
   }
 
-  double HeuristicCostEstimate(Vertex const & v, Vertex const & w) override
+  double HeuristicCostEstimate(Vertex const & v, Vertex const & w, bool /* isOutgoing */) override
   {
     return TimeBetweenSec(v, w, m_maxSpeedMPS);
   }

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -214,7 +214,6 @@ TestAStarBidirectionalAlgo::Result TestAStarBidirectionalAlgo::CalculateRoute(
   Algorithm::Params<> params(roadGraph, startPos, finalPos, {} /* prevRoute */,
                              cancellable);
 
-  // TODO. Add two threads tests.
   Algorithm::Result const res = Algorithm().FindPathBidirectional(params, path);
   return Convert(res);
 }

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -215,7 +215,8 @@ TestAStarBidirectionalAlgo::Result TestAStarBidirectionalAlgo::CalculateRoute(
   Algorithm::Params<> params(roadGraph, startPos, finalPos, {} /* prevRoute */,
                              cancellable);
 
-  Algorithm::Result const res = Algorithm().FindPathBidirectional(params, path);
+  // TODO. Add two threads tests.
+  Algorithm::Result const res = Algorithm().FindPathBidirectional(false /* useTwoThreads */, params, path);
   return Convert(res);
 }
 }  // namespace routing

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -18,7 +18,6 @@ namespace routing_test
 {
 UndirectedGraph::UndirectedGraph()
 {
-  CHECK(!IsTwoThreadsReady(), ());
 }
 
 void UndirectedGraph::AddEdge(Vertex u, Vertex v, Weight w)

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -18,7 +18,7 @@ namespace routing_test
 {
 UndirectedGraph::UndirectedGraph()
 {
-  CHECK(!GetMultithreadingReady(), ());
+  CHECK(!IsTwoThreadsReady(), ());
 }
 
 void UndirectedGraph::AddEdge(Vertex u, Vertex v, Weight w)
@@ -121,7 +121,7 @@ public:
   explicit RoadGraph(IRoadGraph const & roadGraph)
     : m_roadGraph(roadGraph), m_maxSpeedMPS(KMPH2MPS(roadGraph.GetMaxSpeedKMpH()))
   {
-    CHECK(!GetMultithreadingReady(), ());
+    CHECK(!IsTwoThreadsReady(), ());
   }
 
   void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,

--- a/routing/routing_tests/routing_algorithm.cpp
+++ b/routing/routing_tests/routing_algorithm.cpp
@@ -216,7 +216,7 @@ TestAStarBidirectionalAlgo::Result TestAStarBidirectionalAlgo::CalculateRoute(
                              cancellable);
 
   // TODO. Add two threads tests.
-  Algorithm::Result const res = Algorithm().FindPathBidirectional(false /* useTwoThreads */, params, path);
+  Algorithm::Result const res = Algorithm().FindPathBidirectional(params, path);
   return Convert(res);
 }
 }  // namespace routing

--- a/routing/routing_tests/routing_algorithm.hpp
+++ b/routing/routing_tests/routing_algorithm.hpp
@@ -30,6 +30,8 @@ struct SimpleEdge
 class UndirectedGraph : public AStarGraph<uint32_t, SimpleEdge, double>
 {
 public:
+  UndirectedGraph();
+
   void AddEdge(Vertex u, Vertex v, Weight w);
   size_t GetNodesNumber() const;
 

--- a/routing/routing_tests/routing_algorithm.hpp
+++ b/routing/routing_tests/routing_algorithm.hpp
@@ -39,7 +39,7 @@ public:
                            std::vector<Edge> & adj) override;
   void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
                             std::vector<Edge> & adj) override;
-  double HeuristicCostEstimate(Vertex const & v, Vertex const & w) override;
+  double HeuristicCostEstimate(Vertex const & v, Vertex const & w, bool isOutgoing) override;
   // @}
 
   void GetEdgesList(Vertex const & vertex, bool /* isOutgoing */, std::vector<Edge> & adj);

--- a/routing/routing_tests/routing_algorithm.hpp
+++ b/routing/routing_tests/routing_algorithm.hpp
@@ -42,14 +42,20 @@ public:
   void GetOutgoingEdgesList(astar::VertexData<Vertex, Weight> const & vertexData,
                             std::vector<Edge> & adj) override;
   double HeuristicCostEstimate(Vertex const & v, Vertex const & w, bool isOutgoing) override;
+  virtual bool IsTwoThreadsReady() const override { return m_twoThreadsReady; }
   // @}
 
   void GetEdgesList(Vertex const & vertex, bool /* isOutgoing */, std::vector<Edge> & adj);
+  /// \note If |twoThreadsRead| is equal to true it means class should be ready that methods
+  /// GetIngoingEdgesList(), GetOutgoingEdgesList() and HeuristicCostEstimate() are called
+  /// from two threads depending on |isOutgoing| parameter.
+  void SetTwoThreadsReady(bool twoThreadsRead) { m_twoThreadsReady = twoThreadsRead; }
 
 private:
   void GetAdjacencyList(Vertex v, std::vector<Edge> & adj) const;
 
   std::map<uint32_t, std::vector<Edge>> m_adjs;
+  bool m_twoThreadsReady = false;
 };
 
 class DirectedGraph

--- a/routing/routing_tests/routing_session_test.cpp
+++ b/routing/routing_tests/routing_session_test.cpp
@@ -58,9 +58,8 @@ public:
   void ClearState() override {}
   void SetGuides(GuidesTracks && /* guides */) override {}
 
-  RouterResultCode CalculateRoute(Checkpoints const & /* checkpoints */,
-                                  m2::PointD const & /* startDirection */, bool /* adjust */,
-                                  RouterDelegate const & /* delegate */, Route & route) override
+  RouterResultCode CalculateRoute(Checkpoints const & /* checkpoints */, m2::PointD const & /* startDirection */, bool /* useTwoThreads */,
+                                  bool /* adjust */, RouterDelegate const & /* delegate */, Route & route) override
   {
     ++m_buildCount;
     route = m_route;
@@ -90,8 +89,9 @@ public:
   void SetGuides(GuidesTracks && /* guides */) override {}
 
   RouterResultCode CalculateRoute(Checkpoints const & /* checkpoints */,
-                                  m2::PointD const & /* startDirection */, bool /* adjust */,
-                                  RouterDelegate const & /* delegate */, Route & route) override
+                                  m2::PointD const & /* startDirection */, bool /* useTwoThreads */,
+                                  bool /* adjust */, RouterDelegate const & /* delegate */,
+                                  Route & route) override
   {
     TEST_LESS(m_returnCodesIdx, m_returnCodes.size(), ());
     route = Route(GetName(), m_route.begin(), m_route.end(), 0 /* route id */);

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -22,6 +22,7 @@ SingleVehicleWorldGraph::AStarParents<JointSegment>::kEmpty = {};
 SingleVehicleWorldGraph::SingleVehicleWorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph,
                                                  unique_ptr<IndexGraphLoader> loader,
                                                  shared_ptr<EdgeEstimator> estimator,
+                                                 bool twoThreadsReady,
                                                  MwmHierarchyHandler && hierarchyHandler)
   : m_crossMwmGraph(move(crossMwmGraph))
   , m_loader(move(loader))

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -205,7 +205,8 @@ vector<RouteSegment::SpeedCamera> SingleVehicleWorldGraph::GetSpeedCamInfo(Segme
   return m_loader->GetSpeedCameraInfo(segment);
 }
 
-RoadGeometry const & SingleVehicleWorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featureId, bool isOutgoing)
+RoadGeometry const & SingleVehicleWorldGraph::GetRoadGeometry(NumMwmId mwmId, uint32_t featureId,
+                                                              bool isOutgoing)
 {
   return m_loader->GetGeometry(mwmId).GetRoad(featureId, isOutgoing);
 }

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -91,7 +91,7 @@ void SingleVehicleWorldGraph::GetEdgeList(
     astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
     bool useRoutingOptions, bool useAccessConditional, vector<SegmentEdge> & edges)
 {
-  // @TODO It should be ready for calling form two threads if IsTwoThreadsReady() returns true.
+  // @TODO It should be ready for calling from two threads if IsTwoThreadsReady() returns true.
   CHECK_NOT_EQUAL(m_mode, WorldGraphMode::LeapsOnly, ());
 
   ASSERT(m_parentsForSegments.forward && m_parentsForSegments.backward,
@@ -214,7 +214,7 @@ RoadGeometry const & SingleVehicleWorldGraph::GetRoadGeometry(NumMwmId mwmId, ui
 void SingleVehicleWorldGraph::GetTwinsInner(Segment const & segment, bool isOutgoing,
                                             vector<Segment> & twins)
 {
-  // @TODO It should be ready for calling form two threads if IsTwoThreadsReady() returns true.
+  // @TODO It should be ready for calling from two threads if IsTwoThreadsReady() returns true.
   m_crossMwmGraph->GetTwins(segment, isOutgoing, twins);
 }
 

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -91,6 +91,7 @@ void SingleVehicleWorldGraph::GetEdgeList(
     astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
     bool useRoutingOptions, bool useAccessConditional, vector<SegmentEdge> & edges)
 {
+  // @TODO It should be ready for calling form two threads if IsTwoThreadsReady() returns true.
   CHECK_NOT_EQUAL(m_mode, WorldGraphMode::LeapsOnly, ());
 
   ASSERT(m_parentsForSegments.forward && m_parentsForSegments.backward,
@@ -114,7 +115,7 @@ void SingleVehicleWorldGraph::GetEdgeList(
   if (!parent.IsRealSegment())
     return;
 
-  ASSERT(m_parentsForJoints.forward && m_parentsForJoints.backward,
+  ASSERT(isOutgoing ? m_parentsForJoints.forward : m_parentsForJoints.backward,
          ("m_parentsForJoints was not initialized in SingleVehicleWorldGraph."));
   auto & parents = isOutgoing ? *m_parentsForJoints.forward : *m_parentsForJoints.backward;
   auto & indexGraph = GetIndexGraph(parent.GetMwmId());

--- a/routing/single_vehicle_world_graph.cpp
+++ b/routing/single_vehicle_world_graph.cpp
@@ -22,7 +22,6 @@ SingleVehicleWorldGraph::AStarParents<JointSegment>::kEmpty = {};
 SingleVehicleWorldGraph::SingleVehicleWorldGraph(unique_ptr<CrossMwmGraph> crossMwmGraph,
                                                  unique_ptr<IndexGraphLoader> loader,
                                                  shared_ptr<EdgeEstimator> estimator,
-                                                 bool twoThreadsReady,
                                                  MwmHierarchyHandler && hierarchyHandler)
   : m_crossMwmGraph(move(crossMwmGraph))
   , m_loader(move(loader))
@@ -213,6 +212,7 @@ RoadGeometry const & SingleVehicleWorldGraph::GetRoadGeometry(NumMwmId mwmId, ui
 void SingleVehicleWorldGraph::GetTwinsInner(Segment const & segment, bool isOutgoing,
                                             vector<Segment> & twins)
 {
+  // @TODO It should be ready for calling form two threads if IsTwoThreadsReady() returns true.
   m_crossMwmGraph->GetTwins(segment, isOutgoing, twins);
 }
 

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -50,11 +50,12 @@ public:
 
   bool CheckLength(RouteWeight const &, double) const override { return true; }
 
-  LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) override;
-  ms::LatLon const & GetPoint(Segment const & segment, bool front) override;
+  LatLonWithAltitude const & GetJunction(Segment const & segment, bool front,
+                                         bool isOutgoing) override;
+  ms::LatLon const & GetPoint(Segment const & segment, bool front, bool isOutgoing) override;
 
-  bool IsOneWay(NumMwmId mwmId, uint32_t featureId) override;
-  bool IsPassThroughAllowed(NumMwmId mwmId, uint32_t featureId) override;
+  bool IsOneWay(NumMwmId mwmId, uint32_t featureId, bool isOutgoing) override;
+  bool IsPassThroughAllowed(NumMwmId mwmId, uint32_t featureId, bool isOutgoing) override;
   void ClearCachedGraphs() override { m_loader->Clear(); }
 
   void SetMode(WorldGraphMode mode) override { m_mode = mode; }
@@ -62,19 +63,20 @@ public:
 
   RouteWeight HeuristicCostEstimate(ms::LatLon const & from, ms::LatLon const & to) override;
 
-  RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) override;
+  RouteWeight CalcSegmentWeight(Segment const & segment, bool isOutgoing,
+                                EdgeEstimator::Purpose purpose) override;
   RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const override;
   RouteWeight CalcOffroadWeight(ms::LatLon const & from, ms::LatLon const & to,
                                 EdgeEstimator::Purpose purpose) const override;
-  double CalculateETA(Segment const & from, Segment const & to) override;
-  double CalculateETAWithoutPenalty(Segment const & segment) override;
+  double CalculateETA(Segment const & from, Segment const & to, bool isOutgoing) override;
+  double CalculateETAWithoutPenalty(Segment const & segment, bool isOutgoing) override;
 
   std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter) override;
 
   void SetRoutingOptions(RoutingOptions routingOptions) override { m_avoidRoutingOptions = routingOptions; }
   /// \returns true if feature, associated with segment satisfies users conditions.
-  bool IsRoutingOptionsGood(Segment const & segment) override;
-  RoutingOptions GetRoutingOptions(Segment const & segment) override;
+  bool IsRoutingOptionsGood(Segment const & segment, bool isOutgoing) override;
+  RoutingOptions GetRoutingOptions(Segment const & segment, bool isOutgoing) override;
 
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
   std::vector<RouteSegment::SpeedCamera> GetSpeedCamInfo(Segment const & segment) override;
@@ -124,7 +126,7 @@ private:
   // WorldGraph overrides:
   void GetTwinsInner(Segment const & s, bool isOutgoing, std::vector<Segment> & twins) override;
 
-  RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId);
+  RoadGeometry const & GetRoadGeometry(NumMwmId mwmId, uint32_t featureId, bool isOutgoing);
 
   std::unique_ptr<CrossMwmGraph> m_crossMwmGraph;
   std::unique_ptr<IndexGraphLoader> m_loader;

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -31,7 +31,6 @@ public:
   SingleVehicleWorldGraph(std::unique_ptr<CrossMwmGraph> crossMwmGraph,
                           std::unique_ptr<IndexGraphLoader> loader,
                           std::shared_ptr<EdgeEstimator> estimator,
-                          bool twoThreadsReady,
                           MwmHierarchyHandler && hierarchyHandler);
 
   // WorldGraph overrides:
@@ -97,6 +96,7 @@ public:
   bool AreWavesConnectible(Parents<JointSegment> & forwardParents, JointSegment const & commonVertex,
                            Parents<JointSegment> & backwardParents,
                            std::function<uint32_t(JointSegment const &)> && fakeFeatureConverter) override;
+  bool IsTwoThreadsReady() const override { return m_loader->IsTwoThreadsReady(); }
   // @}
 
   // This method should be used for tests only

--- a/routing/single_vehicle_world_graph.hpp
+++ b/routing/single_vehicle_world_graph.hpp
@@ -31,6 +31,7 @@ public:
   SingleVehicleWorldGraph(std::unique_ptr<CrossMwmGraph> crossMwmGraph,
                           std::unique_ptr<IndexGraphLoader> loader,
                           std::shared_ptr<EdgeEstimator> estimator,
+                          bool twoThreadsReady,
                           MwmHierarchyHandler && hierarchyHandler);
 
   // WorldGraph overrides:

--- a/routing/transit_world_graph.hpp
+++ b/routing/transit_world_graph.hpp
@@ -51,24 +51,26 @@ public:
     return weight.GetWeight() - weight.GetTransitTime() <=
            MaxPedestrianTimeSec(startToFinishDistanceM);
   }
-  LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) override;
-  ms::LatLon const & GetPoint(Segment const & segment, bool front) override;
+  LatLonWithAltitude const & GetJunction(Segment const & segment, bool front,
+                                         bool isOutgoing) override;
+  ms::LatLon const & GetPoint(Segment const & segment, bool front, bool isOutgoing) override;
   // All transit features are oneway.
-  bool IsOneWay(NumMwmId mwmId, uint32_t featureId) override;
+  bool IsOneWay(NumMwmId mwmId, uint32_t featureId, bool isOutgoing) override;
   // All transit features are allowed for through passage.
-  bool IsPassThroughAllowed(NumMwmId mwmId, uint32_t featureId) override;
+  bool IsPassThroughAllowed(NumMwmId mwmId, uint32_t featureId, bool isOutgoing) override;
   void ClearCachedGraphs() override;
   void SetMode(WorldGraphMode mode) override { m_mode = mode; }
   WorldGraphMode GetMode() const override { return m_mode; }
 
   RouteWeight HeuristicCostEstimate(ms::LatLon const & from, ms::LatLon const & to) override;
 
-  RouteWeight CalcSegmentWeight(Segment const & segment, EdgeEstimator::Purpose purpose) override;
+  RouteWeight CalcSegmentWeight(Segment const & segment, bool isOutgoing,
+                                EdgeEstimator::Purpose purpose) override;
   RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const override;
   RouteWeight CalcOffroadWeight(ms::LatLon const & from, ms::LatLon const & to,
                                 EdgeEstimator::Purpose purpose) const override;
-  double CalculateETA(Segment const & from, Segment const & to) override;
-  double CalculateETAWithoutPenalty(Segment const & segment) override;
+  double CalculateETA(Segment const & from, Segment const & to, bool /* isOutgoing */) override;
+  double CalculateETAWithoutPenalty(Segment const & segment, bool /* isOutgoing */) override;
 
   std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) override;
 
@@ -88,7 +90,7 @@ private:
     return 50 * 60 + (startToFinishDistanceM / 1000) * 3 * 60;
   }
 
-  RoadGeometry const & GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId);
+  RoadGeometry const & GetRealRoadGeometry(NumMwmId mwmId, uint32_t featureId, bool isOutgoing);
   void AddRealEdges(astar::VertexData<Segment, RouteWeight> const & vertexData, bool isOutgoing,
                     bool useRoutingOptions, std::vector<SegmentEdge> & edges);
   TransitGraph & GetTransitGraph(NumMwmId mwmId);

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -28,12 +28,12 @@ void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, bool useRout
   SetMode(prevMode);
 }
 
-RoutingOptions WorldGraph::GetRoutingOptions(Segment const & /* segment */)
+RoutingOptions WorldGraph::GetRoutingOptions(Segment const & /* segment */, bool /* isOutgoing */)
 {
   return {};
 }
 
-bool WorldGraph::IsRoutingOptionsGood(Segment const & /* segment */)
+bool WorldGraph::IsRoutingOptionsGood(Segment const & /* segment */, bool /* isOutgoing */)
 {
   return true;
 }

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -14,6 +14,7 @@ void WorldGraph::GetEdgeList(Segment const & vertex, bool isOutgoing, bool useRo
 void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
                           std::vector<SegmentEdge> & edges)
 {
+  // @TODO It should be ready for calling form two threads if IsTwoThreadsReady() returns true.
   std::vector<Segment> twins;
   GetTwinsInner(segment, isOutgoing, twins);
 

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -14,7 +14,6 @@ void WorldGraph::GetEdgeList(Segment const & vertex, bool isOutgoing, bool useRo
 void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
                           std::vector<SegmentEdge> & edges)
 {
-  // @TODO It should be ready for calling from two threads if IsTwoThreadsReady() returns true.
   std::vector<Segment> twins;
   GetTwinsInner(segment, isOutgoing, twins);
 

--- a/routing/world_graph.cpp
+++ b/routing/world_graph.cpp
@@ -14,7 +14,7 @@ void WorldGraph::GetEdgeList(Segment const & vertex, bool isOutgoing, bool useRo
 void WorldGraph::GetTwins(Segment const & segment, bool isOutgoing, bool useRoutingOptions,
                           std::vector<SegmentEdge> & edges)
 {
-  // @TODO It should be ready for calling form two threads if IsTwoThreadsReady() returns true.
+  // @TODO It should be ready for calling from two threads if IsTwoThreadsReady() returns true.
   std::vector<Segment> twins;
   GetTwinsInner(segment, isOutgoing, twins);
 

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -65,12 +65,12 @@ public:
   // start to finish of the route.
   virtual bool CheckLength(RouteWeight const & weight, double startToFinishDistanceM) const = 0;
 
-  virtual LatLonWithAltitude const & GetJunction(Segment const & segment, bool front) = 0;
-  virtual ms::LatLon const & GetPoint(Segment const & segment, bool front) = 0;
-  virtual bool IsOneWay(NumMwmId mwmId, uint32_t featureId) = 0;
+  virtual LatLonWithAltitude const & GetJunction(Segment const & segment, bool front, bool isOutgoing) = 0;
+  virtual ms::LatLon const & GetPoint(Segment const & segment, bool front, bool isOutgoing) = 0;
+  virtual bool IsOneWay(NumMwmId mwmId, uint32_t featureId, bool isOutgoing) = 0;
 
   // Checks whether feature is allowed for through passage.
-  virtual bool IsPassThroughAllowed(NumMwmId mwmId, uint32_t featureId) = 0;
+  virtual bool IsPassThroughAllowed(NumMwmId mwmId, uint32_t featureId, bool isOutgoing) = 0;
 
   // Clear memory used by loaded graphs.
   virtual void ClearCachedGraphs() = 0;
@@ -79,7 +79,7 @@ public:
 
   virtual RouteWeight HeuristicCostEstimate(ms::LatLon const & from, ms::LatLon const & to) = 0;
 
-  virtual RouteWeight CalcSegmentWeight(Segment const & segment,
+  virtual RouteWeight CalcSegmentWeight(Segment const & segment, bool isOutgoing,
                                         EdgeEstimator::Purpose purpose) = 0;
 
   virtual RouteWeight CalcLeapWeight(ms::LatLon const & from, ms::LatLon const & to) const = 0;
@@ -87,14 +87,14 @@ public:
   virtual RouteWeight CalcOffroadWeight(ms::LatLon const & from, ms::LatLon const & to,
                                         EdgeEstimator::Purpose purpose) const = 0;
 
-  virtual double CalculateETA(Segment const & from, Segment const & to) = 0;
-  virtual double CalculateETAWithoutPenalty(Segment const & segment) = 0;
+  virtual double CalculateETA(Segment const & from, Segment const & to, bool /* isOutgoing */) = 0;
+  virtual double CalculateETAWithoutPenalty(Segment const & segment, bool /* isOutgoing */) = 0;
 
   /// \returns transitions for mwm with id |numMwmId|.
   virtual std::vector<Segment> const & GetTransitions(NumMwmId numMwmId, bool isEnter);
 
-  virtual bool IsRoutingOptionsGood(Segment const & /* segment */);
-  virtual RoutingOptions GetRoutingOptions(Segment const & /* segment */);
+  virtual bool IsRoutingOptionsGood(Segment const & /* segment */, bool /* isOutgoing */);
+  virtual RoutingOptions GetRoutingOptions(Segment const & /* segment */, bool /* isOutgoing */);
   virtual void SetRoutingOptions(RoutingOptions /* routingOptions */);
 
   virtual void SetAStarParents(bool forward, Parents<Segment> & parents);

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -28,6 +28,20 @@
 
 namespace routing
 {
+/// \Note. About isOutgoing parameter.
+/// In routing in hundreds of method isOutgoing boolean flag is used. This flag have
+/// several meanings.
+/// - Originally this parameter was added to distinguish getting ingoing graph edges and
+///   outgoing graph edges. For example, if it's necessary to get outgoing edges
+///   GetEdgeList(..., true /* isOutgoing */, ...) should be called and to get ingoing
+///   graph edges GetEdgeList(..., false /* isOutgoing */, ...) should be called.
+/// - On the other hand getting ingoing edges (isOutgoing == false) only for backward wave
+///   in bidirectional A*. So it's possible to say that based on isOutgoing value
+///   it's possible to say which wave in bidirectional A* is used.
+/// - Then two-threads variant was implemented for bidirectional A*. A new thread is created
+///   for backward A* bidirectional wave in this case. So if isOutgoing == false
+///   that means the method is called from this additional thread.
+
 enum class WorldGraphMode
 {
   LeapsOnly,       // Mode for building a cross mwm route containing only leaps. In case of start and

--- a/routing/world_graph.hpp
+++ b/routing/world_graph.hpp
@@ -108,6 +108,8 @@ public:
                                    Parents<JointSegment> & backwardParents,
                                    std::function<uint32_t(JointSegment const &)> && fakeFeatureConverter);
 
+  virtual bool IsTwoThreadsReady() const { return false; }
+
   /// \returns transit-specific information for segment. For nontransit segments returns nullptr.
   virtual std::unique_ptr<TransitInfo> GetTransitInfo(Segment const & segment) = 0;
 

--- a/track_analyzing/track_analyzer/cmd_table.cpp
+++ b/track_analyzing/track_analyzer/cmd_table.cpp
@@ -407,7 +407,8 @@ void CmdTagsTable(string const & filepath, string const & trackExtension, String
     Geometry geometry(GeometryLoader::CreateFromFile(mwmFile, vehicleModel));
     auto const vehicleType = VehicleType::Car;
     auto const edgeEstimator = EdgeEstimator::Create(vehicleType, *vehicleModel, nullptr /* trafficStash */);
-    auto indexGraphLoader = IndexGraphLoader::Create(vehicleType, false /* loadAltitudes */, numMwmIds,
+    auto indexGraphLoader = IndexGraphLoader::Create(vehicleType, false /* loadAltitudes */,
+                                                     false /* twoThreadsReady */, numMwmIds,
                                                      carModelFactory, edgeEstimator, dataSource);
 
     platform::CountryFile const countryFile(mwmName);

--- a/track_analyzing/track_analyzer/cmd_tracks.cpp
+++ b/track_analyzing/track_analyzer/cmd_tracks.cpp
@@ -115,8 +115,9 @@ double EstimateDuration(MatchedTrack const & track, shared_ptr<EdgeEstimator> es
       continue;
 
     segment = point.GetSegment();
-    result += estimator->CalcSegmentWeight(segment, geometry.GetRoad(segment.GetFeatureId()),
-                                           EdgeEstimator::Purpose::ETA);
+    result += estimator->CalcSegmentWeight(
+        segment, geometry.GetRoad(segment.GetFeatureId(), true /* isOutgoing */),
+        EdgeEstimator::Purpose::ETA);
   }
 
   return result;

--- a/track_analyzing/track_analyzer/crossroad_checker.cpp
+++ b/track_analyzing/track_analyzer/crossroad_checker.cpp
@@ -78,9 +78,11 @@ namespace routing
 IsCrossroadChecker::Type IsCrossroadChecker::operator()(Segment const & current, Segment const & next) const
 {
   auto const currentSegmentFeatureId = current.GetFeatureId();
-  auto const currentSegmentHwType = m_geometry.GetRoad(currentSegmentFeatureId).GetHighwayType();
+  auto const currentSegmentHwType =
+      m_geometry.GetRoad(currentSegmentFeatureId, true /* isOutgoing */).GetHighwayType();
   auto const nextSegmentFeatureId = next.GetFeatureId();
-  auto const nextSegmentHwType = m_geometry.GetRoad(nextSegmentFeatureId).GetHighwayType();
+  auto const nextSegmentHwType =
+      m_geometry.GetRoad(nextSegmentFeatureId, true /* isOutgoing */).GetHighwayType();
   auto const currentRoadPoint = current.GetRoadPoint(true /* isFront */);
   auto const jointId = m_indexGraph.GetJointId(currentRoadPoint);
   if (jointId == Joint::kInvalidId)
@@ -121,7 +123,7 @@ IsCrossroadChecker::Type IsCrossroadChecker::operator()(Segment const & current,
     if (pointFeatureId == currentSegmentFeatureId || pointFeatureId == nextSegmentFeatureId)
       return;
 
-    auto const & roadGeometry = m_geometry.GetRoad(pointFeatureId);
+    auto const & roadGeometry = m_geometry.GetRoad(pointFeatureId, true /* isOutgoing */);
     auto const pointHwType = roadGeometry.GetHighwayType();
     if (currentSegmentHwType == pointHwType)
       return;

--- a/track_analyzing/track_matcher.cpp
+++ b/track_analyzing/track_matcher.cpp
@@ -34,9 +34,11 @@ double DistanceToSegment(m2::PointD const & segmentBegin, m2::PointD const & seg
 
 double DistanceToSegment(Segment const & segment, m2::PointD const & point, IndexGraph & indexGraph)
 {
-  return DistanceToSegment(
-      mercator::FromLatLon(indexGraph.GetGeometry().GetPoint(segment.GetRoadPoint(false))),
-      mercator::FromLatLon(indexGraph.GetGeometry().GetPoint(segment.GetRoadPoint(true))), point);
+  return DistanceToSegment(mercator::FromLatLon(indexGraph.GetGeometry().GetPoint(
+                               segment.GetRoadPoint(false /* front */), true /* isOutgoing */)),
+                           mercator::FromLatLon(indexGraph.GetGeometry().GetPoint(
+                               segment.GetRoadPoint(true /* front */), true /* isOutgoing */)),
+                           point);
 }
 
 bool EdgesContain(vector<SegmentEdge> const & edges, Segment const & segment)

--- a/track_analyzing/track_matcher.cpp
+++ b/track_analyzing/track_matcher.cpp
@@ -71,7 +71,7 @@ TrackMatcher::TrackMatcher(storage::Storage const & storage, NumMwmId mwmId,
   m_graph = make_unique<IndexGraph>(
       make_shared<Geometry>(GeometryLoader::Create(m_dataSource, handle, m_vehicleModel,
                                                    AttrLoader(m_dataSource, handle),
-                                                   false /* loadAltitudes */)),
+                                                   false /* loadAltitudes */, false /* twoThreadsReady */)),
       EdgeEstimator::Create(VehicleType::Car, *m_vehicleModel, nullptr /* trafficStash */));
 
   DeserializeIndexGraph(*handle.GetValue(), VehicleType::Car, *m_graph);

--- a/track_analyzing/utils.cpp
+++ b/track_analyzing/utils.cpp
@@ -31,8 +31,8 @@ double CalcSubtrackLength(MatchedTrack::const_iterator begin, MatchedTrack::cons
     {
       length +=
           ms::DistanceOnEarth(
-          geometry.GetPoint(segment.GetRoadPoint(false /* front */)),
-          geometry.GetPoint(segment.GetRoadPoint(true /* front */)));
+          geometry.GetPoint(segment.GetRoadPoint(false /* front */), true /* isOutgoing */),
+          geometry.GetPoint(segment.GetRoadPoint(true /* front */), true /* isOutgoing */));
       prevSegment = segment;
     }
   }


### PR DESCRIPTION
**Решаемая задача:**
На мобильных девайсах сейчас обычно 2 и более ядер. Как показали тесты, загрузка двух потоков обычно раскладывается шедулером на 2 ядра, даже на 2 ядерных девайсах (тесты были на iPhone SE). Мы прокладываем маршруты при помощи 2х стороннего A*. Прототип и тесты на нем (iPhone SE, Galaxy s10e) показали, что можно сделать, чтоб 2 потока работали при прокладке относительно не зависимо и, если каждому из них досталось свое ядро, то маршруты должны прокладываться существенно быстрее. Данный PR реализует это.

**План работ:**
Данный PR реализует двусторонний A* и структуры данных для него, которые позволяют искать маршруты, как в 2 потока (по одному на каждую волну), так и в один поток. Чтоб воспользоваться поиском маршрута в 2 потока нужно использовать SingleVehicleWorldGraph(IndexGraphStarter/IndexGraphStarterJoints) созданный для поиска в 2 потока.

После данного PR-та будет PR с тестами на эффективность и корректность, которые будут работать на приличной выборке маршрутов.
Затем будет PR с возможностью отключать двусторонний A* и использовать односторонний при помощи специального флажка, чтоб было проще тестировать в ручную.

В этот PR не войдет, хотя в будущем можно сделать:
* поиск в 2 потока межmwm-го маршрута (шаг с leaps)
* поиск в 2 потока при помощи: `void SingleVehicleWorldGraph::GetEdgeList(astar::VertexData<**Segment**, RouteWeight> const & vertexData …)`. Данный PR реализацет поиск в 2 потока только при помощи: void `SingleVehicleWorldGraph::GetEdgeList(astar::VertexData<**JointSegment**, RouteWeight> const & parentVertexData …)`
* поиск в 2 потока лучших сегментов около стартовой и конечной вершин.

**Краткое описание алгоритма:**
Основаная идея проста. 2 волны A* исполняются в 2 потоках раскрывая вершины на встречу друг другу. Пока они не соприкоснулись они движутся навстречу друг другу (это обычно основное время работы алгоритма) используется относительно мало общих данных. После соприкосновения волн работа алгоритма не заканчивается, но кол-во общих данных, используемых двумя волнами, существенно возрастает. Реализация в данном PR переключается на однопоточный вариант, как только волны соприкоснутся. Пока они не соприкоснулись есть только два набора общих данных: (1) очередь BidirectionalStepContext::bestDistance. Каждой волне важен доступ до очереди противоположенной волны, чтоб понять, пересеклись ли они; (2) Граф. Получение входящих и исходящих дуг, и вычисление эвристики.

Исследования показали, что если обращения к очереди (1) защитить мьютексом, то это не очень сильно сказывается на производительности.
Основные работы проведены над графом. Если сериализовать мьютексом получение входящих и исходящих дуг графа, то это критически повлияет на производительность. С другой стороны, этого и не нужно делать. В целом обращение за дугами, это операция чтения. Если сделать отдельные кеши (кеш полученной геометрии и кеш при файлом чтении) для обоих потоков, то останется синхронизировать очень не большие объемы кода (подргузка новых графов при распространении волны и т.п.). Так же, чтоб можно было получить входящие и исходящие дуги из разных потоков нужно сделать отдельные кеши для чтения с диска для каждого потока.

**Корректность:**
Математическая корректность - я постараюсь выделить время, на то чтоб доказать, что то что написано математически корректно. На интуитивном уровне кажется, что это так.
Тесты. Будут проведены и выложены в след за этим PR сравнительные тесты на большой выборке маршрутов.

**Реализация**
Идея в том, чтоб если используется поис маршрута в один поток (SingleVehicleWorldGraph(IndexGraphStarter/IndexGraphStarterJoints) созданный для поиска в 1 поток), то не должно быть существенных накладных расходов. Если же в 2 потока, то должны добавиться минимальные расходы на синхронизацию и дополнительные кеши для геометрии и кеш чтения с диска. В случае 2 потоков, используется второй поток для обратной волны A*, которая идет от финиша. Какой из 2 кешей использовать, определяется при помощи параметра isOutgoing. Именно он определяет, для какой волны сейчас используются методы. В данном PR он прокинут в большое число методов.

**Результаты сравнительных тестов на 16.11.2020**
Первые тесты.
iPhone SE. Пеший маршрут: Тушино (Москва) - Таруса (55.857793, 37.409484; 54.719608, 37.194492). 

8 прокладок подряд:
iPhone SE
Route build time: 44599 ms - 1 поток
Route build time: 31637 ms - 2 потока
Route build time: 30543 ms - 2 потока
Route build time: 39362 ms - 1 поток

Route build time: 40235 ms - 1 поток
Route build time: 30402 ms - 2 потока
Route build time: 30126 ms - 2 потока
Route build time: 39376 ms - 1 поток

s10e
Route build time: 14925 ms - 1 поток
Route build time: 9595 ms - 2 потока
Route build time: 9749 ms - 2 потока
Route build time: 14386 ms - 1 поток

Route build time: 14307 ms - 1 поток
Route build time: 9697 ms - 2 потока
Route build time: 9823 ms - 2 потока
Route build time: 14564 ms - 1 поток

Длина и ETA во всех прокладках одинаковая

Для сравнения две прокладки аналогичного маршрута на мастере (в один поток) на iPhoneSE дали:
Route build time: 44830 ms
Route build time: 40719 ms
Route build time: 39935 ms

routing integration tests и routing quality tests проходят.

@mesozoic-drones @mpimenov PTAL