### PR TITLE
[qt] Fix for ignoring function's val with 'warn_unused_result'.

### DIFF
--- a/qt/routing_settings_dialog.cpp
+++ b/qt/routing_settings_dialog.cpp
@@ -32,8 +32,10 @@ std::string const RoutingSettings::kRouterTypeCachedSettings = "router_type_desk
 bool RoutingSettings::TurnsEnabled()
 {
   bool enabled = false;
-  settings::Get(kShowTurnsSettings, enabled);
-  return enabled;
+  if (settings::Get(kShowTurnsSettings, enabled))
+    return enable;
+
+  return false;
 }
 
 // static


### PR DESCRIPTION
Fix for warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result].