### PR TITLE
[generator] Save name:ja-Hira if there is no name:ja_kana.

### DIFF
--- a/generator/generator_tests/osm_type_test.cpp
+++ b/generator/generator_tests/osm_type_test.cpp
@@ -942,6 +942,75 @@ UNIT_CLASS_TEST(TestWithClassificator, OsmType_AltName)
   }
 }
 
+UNIT_CLASS_TEST(TestWithClassificator, OsmType_NameJaKana)
+{
+  {
+    Tags const tags = {
+      {"place", "city"},
+      {"name", "Tokyo"},
+      {"name:ja_kana", "トウキョウト"}
+    };
+
+    auto const params = GetFeatureBuilderParams(tags);
+
+    std::string s;
+    params.name.GetString(StringUtf8Multilang::kDefaultCode, s);
+    TEST_EQUAL(s, "Tokyo", ());
+    params.name.GetString(StringUtf8Multilang::GetLangIndex("ja_kana"), s);
+    TEST_EQUAL(s, "トウキョウト", ());
+  }
+  {
+    Tags const tags = {
+      {"place", "city"},
+      {"name", "Tokyo"},
+      {"name:ja-Hira", "とうきょうと"}
+    };
+
+    auto const params = GetFeatureBuilderParams(tags);
+
+    std::string s;
+    params.name.GetString(StringUtf8Multilang::kDefaultCode, s);
+    TEST_EQUAL(s, "Tokyo", ());
+    // Save ja-Hira as ja_kana if there is no ja_kana.
+    params.name.GetString(StringUtf8Multilang::GetLangIndex("ja_kana"), s);
+    TEST_EQUAL(s, "とうきょうと", ());
+  }
+  {
+    Tags const tags = {
+      {"place", "city"},
+      {"name", "Tokyo"},
+      {"name:ja_kana", "トウキョウト"},
+      {"name:ja-Hira", "とうきょうと"}
+    };
+
+    auto const params = GetFeatureBuilderParams(tags);
+
+    std::string s;
+    params.name.GetString(StringUtf8Multilang::kDefaultCode, s);
+    TEST_EQUAL(s, "Tokyo", ());
+    // Prefer ja_kana over ja-Hira. ja_kana tag goes first.
+    params.name.GetString(StringUtf8Multilang::GetLangIndex("ja_kana"), s);
+    TEST_EQUAL(s, "トウキョウト", ());
+  }
+  {
+    Tags const tags = {
+      {"place", "city"},
+      {"name", "Tokyo"},
+      {"name:ja-Hira", "とうきょうと"},
+      {"name:ja_kana", "トウキョウト"}
+    };
+
+    auto const params = GetFeatureBuilderParams(tags);
+
+    std::string s;
+    params.name.GetString(StringUtf8Multilang::kDefaultCode, s);
+    TEST_EQUAL(s, "Tokyo", ());
+    // Prefer ja_kana over ja-Hira. ja-Hira tag goes first.
+    params.name.GetString(StringUtf8Multilang::GetLangIndex("ja_kana"), s);
+    TEST_EQUAL(s, "トウキョウト", ());
+  }
+}
+
 UNIT_CLASS_TEST(TestWithClassificator, OsmType_MergeTags)
 {
   {

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -48,7 +48,8 @@ public:
   {
     Forbid,
     Accept,
-    Append
+    Append,
+    Replace
   };
 
   explicit NamesExtractor(FeatureBuilderParams & params) : m_params(params) {}
@@ -95,6 +96,17 @@ public:
     if (lang == "ar1")
       lang = "ar";
 
+    if (lang == "ja-Hira")
+    {
+      // Save "ja-Hira" if there is no "ja_kana".
+      lang = "ja_kana";
+    }
+    else if (lang == "ja_kana")
+    {
+      // Prefer "ja_kana" over "ja-Hira".
+      return LangAction::Replace;
+    }
+
     return LangAction::Accept;
   }
 
@@ -108,6 +120,7 @@ public:
     {
     case LangAction::Forbid: return;
     case LangAction::Accept: m_names.emplace(move(lang), move(v)); break;
+    case LangAction::Replace: swap(m_names[lang], v); break;
     case LangAction::Append:
       auto & name = m_names[lang];
       if (name.empty())


### PR DESCRIPTION
В японском есть две слоговых азбуки -- катакана и хирагана. В name:ja_kana может быть записано имя на любой из них. Также есть тег name:ja-Hira в котором содержится имя на хирагане. В OCM 57к name:ja-Hira и 53к name:ja_kana.

У нас в StringUtf8Multilang есть ja_kana и нет ja-Hira (и кажется не нужно добавлять). Предлагается при отсутствии ja_kana и наличии ja-Hira сохранять ja-Hira из ОСМ в ja_kana в StringUtf8Multilang. Т.к. в name:ja_kana может быть как катакана так и хирагана не вижу в этом ничего плохого.