### PR TITLE
[routing][generator] Ser/des for routing section in new format for World.mwm.

### DIFF
--- a/defines.hpp
+++ b/defines.hpp
@@ -60,6 +60,7 @@
 #define CITY_ROADS_FILE_TAG "city_roads"
 #define DESCRIPTIONS_FILE_TAG "descriptions"
 #define MAXSPEEDS_FILE_TAG "maxspeeds"
+#define ROUTING_WORLD_FILE_TAG "routing_world"
 
 #define READY_FILE_EXTENSION ".ready"
 #define RESUME_FILE_EXTENSION ".resume"

--- a/routing/CMakeLists.txt
+++ b/routing/CMakeLists.txt
@@ -28,6 +28,8 @@ set(
   city_roads.hpp
   city_roads_serialization.hpp
   coding.hpp
+  cross_border_graph.cpp
+  cross_border_graph.hpp
   cross_mwm_connector.cpp
   cross_mwm_connector.hpp
   cross_mwm_connector_serialization.cpp

--- a/routing/cross_border_graph.cpp
+++ b/routing/cross_border_graph.cpp
@@ -1,0 +1,62 @@
+#include "routing/cross_border_graph.hpp"
+
+namespace routing
+{
+void CrossBorderGraph::AddCrossBorderSegment(RegionSegmentId segId,
+                                             CrossBorderSegment const & segment)
+{
+  m_segments.emplace(segId, segment);
+
+  auto addEndingToMwms = [&](CrossBorderSegmentEnding const & ending) {
+    auto const & [it, inserted] =
+        m_mwms.emplace(ending.m_numMwmId, std::vector<RegionSegmentId>{segId});
+    if (!inserted)
+      it->second.push_back(segId);
+  };
+
+  addEndingToMwms(segment.m_start);
+  addEndingToMwms(segment.m_end);
+}
+
+// static
+double CrossBorderGraphSerializer::SerDesVals::GetMin() { return ms::LatLon::kMinLat; }
+// static
+double CrossBorderGraphSerializer::SerDesVals::GetMax() { return ms::LatLon::kMaxLat; }
+
+CrossBorderSegmentEnding::CrossBorderSegmentEnding(m2::PointD const & point, NumMwmId const & mwmId)
+  : m_point(mercator::ToLatLon(point), geometry::kDefaultAltitudeMeters), m_numMwmId(mwmId)
+{
+}
+
+CrossBorderSegmentEnding::CrossBorderSegmentEnding(ms::LatLon const & point, NumMwmId const & mwmId)
+  : m_point(point, 0), m_numMwmId(mwmId)
+{
+}
+
+CrossBorderGraphSerializer::Header::Header(CrossBorderGraph const & graph, uint32_t version)
+  : m_numRegions(static_cast<uint32_t>(graph.m_mwms.size()))
+  , m_numRoads(static_cast<uint32_t>(graph.m_segments.size()))
+  , m_version(version)
+{
+}
+
+// static
+uint32_t CrossBorderGraphSerializer::Hash(std::string const & s)
+{
+  // We use RSHash (Real Simple Hash) variation. RSHash is a standard hash calculating function
+  // described in Robert Sedgwick's "Algorithms in C". The difference between this implementation
+  // and the original algorithm is that we return hash, not (hash & & 0x7FFFFFFF).
+  uint32_t constexpr b = 378551;
+  uint32_t a = 63689;
+
+  uint32_t hash = 0;
+
+  for (auto c : s)
+  {
+    hash = hash * a + c;
+    a *= b;
+  }
+
+  return hash;
+}
+}  // namespace routing

--- a/routing/cross_border_graph.hpp
+++ b/routing/cross_border_graph.hpp
@@ -1,0 +1,250 @@
+#pragma once
+
+#include "routing/latlon_with_altitude.hpp"
+
+#include "routing_common/num_mwm_id.hpp"
+
+#include "coding/point_coding.hpp"
+#include "coding/reader.hpp"
+#include "coding/write_to_sink.hpp"
+
+#include "geometry/mercator.hpp"
+#include "geometry/point2d.hpp"
+#include "geometry/point_with_altitude.hpp"
+
+#include "base/assert.hpp"
+#include "base/logging.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace routing
+{
+uint32_t constexpr kLatestVersionRoutingWorldSection = 0;
+
+using RegionSegmentId = uint32_t;
+
+struct CrossBorderSegmentEnding
+{
+  CrossBorderSegmentEnding() = default;
+  CrossBorderSegmentEnding(m2::PointD const & point, NumMwmId const & mwmId);
+  CrossBorderSegmentEnding(ms::LatLon const & point, NumMwmId const & mwmId);
+
+  LatLonWithAltitude m_point;
+  NumMwmId m_numMwmId = std::numeric_limits<NumMwmId>::max();
+};
+
+struct CrossBorderSegment
+{
+  CrossBorderSegmentEnding m_start;
+  CrossBorderSegmentEnding m_end;
+
+  double m_weight = 0.0;
+};
+
+using CrossBorderSegments = std::unordered_map<RegionSegmentId, CrossBorderSegment>;
+using MwmIdToSegmentIds = std::unordered_map<NumMwmId, std::vector<RegionSegmentId>>;
+
+struct CrossBorderGraph
+{
+  void AddCrossBorderSegment(RegionSegmentId segId, CrossBorderSegment const & segment);
+
+  CrossBorderSegments m_segments;
+  MwmIdToSegmentIds m_mwms;
+};
+
+class CrossBorderGraphSerializer
+{
+public:
+  CrossBorderGraphSerializer() = delete;
+
+  template <class Sink>
+  static void Serialize(CrossBorderGraph const & graph, Sink & sink,
+                        std::shared_ptr<NumMwmIds> numMwmIds);
+
+  template <class Source>
+  static void Deserialize(CrossBorderGraph & graph, Source & src,
+                          std::shared_ptr<NumMwmIds> numMwmIds);
+
+private:
+  struct Header
+  {
+    Header() = default;
+    explicit Header(CrossBorderGraph const & graph,
+                    uint32_t version = kLatestVersionRoutingWorldSection);
+
+    template <class Sink>
+    void Serialize(Sink & sink) const;
+
+    template <class Source>
+    void Deserialize(Source & src);
+
+    uint32_t m_numRegions = 0;
+    uint32_t m_numRoads = 0;
+
+    uint32_t m_version = kLatestVersionRoutingWorldSection;
+  };
+
+  // Constants for point-coding of double fields (coordinates and edge weight).
+  class SerDesVals
+  {
+  public:
+    static double GetMin();
+    static double GetMax();
+    static constexpr size_t GetBitsCount() { return kBitsForDouble; }
+
+  private:
+    static size_t constexpr kBitsForDouble = 30;
+  };
+
+  static uint32_t Hash(std::string const & s);
+};
+
+// static
+template <class Sink>
+void CrossBorderGraphSerializer::Serialize(CrossBorderGraph const & graph, Sink & sink,
+                                           std::shared_ptr<NumMwmIds> numMwmIds)
+{
+  Header header(graph);
+  header.Serialize(sink);
+
+  std::set<uint32_t> mwmNameHashes;
+
+  for (auto it = graph.m_mwms.begin(); it != graph.m_mwms.end(); ++it)
+  {
+    auto const & mwmId = it->first;
+    std::string const & mwmName = numMwmIds->GetFile(mwmId).GetName();
+    auto const hash = Hash(mwmName);
+
+    // Triggering of this check during the maps build means that the mwm set has been changed and
+    // current hash function Hash(mwmName) no longer suits it and should be replaced.
+    CHECK(mwmNameHashes.emplace(hash).second, (mwmId, mwmName, hash));
+  }
+
+  for (auto hash : mwmNameHashes)
+    WriteToSink(sink, hash);
+
+  auto writeVal = [&sink](double val, bool isCoord = true) {
+    WriteToSink(sink, DoubleToUint32(val, SerDesVals::GetMin(), SerDesVals::GetMax(),
+                                     SerDesVals::GetBitsCount()));
+  };
+
+  auto writeSegEnding = [&](CrossBorderSegmentEnding const & ending) {
+    auto const & coord = ending.m_point.GetLatLon();
+    writeVal(coord.m_lat);
+    writeVal(coord.m_lon);
+
+    auto const & mwmNameHash = Hash(numMwmIds->GetFile(ending.m_numMwmId).GetName());
+    auto it = mwmNameHashes.find(mwmNameHash);
+    CHECK(it != mwmNameHashes.end(), (ending.m_numMwmId, mwmNameHash));
+
+    NumMwmId id = std::distance(mwmNameHashes.begin(), it);
+    WriteToSink(sink, id);
+  };
+
+  for (auto const & [segId, seg] : graph.m_segments)
+  {
+    WriteToSink(sink, segId);
+
+    double const weightRounded = std::ceil(seg.m_weight);
+    CHECK_LESS(weightRounded, std::numeric_limits<uint32_t>::max(), (weightRounded));
+
+    WriteToSink(sink, static_cast<uint32_t>(weightRounded));
+    writeSegEnding(seg.m_start);
+    writeSegEnding(seg.m_end);
+  }
+}
+
+// static
+template <class Source>
+void CrossBorderGraphSerializer::Deserialize(CrossBorderGraph & graph, Source & src,
+                                             std::shared_ptr<NumMwmIds> numMwmIds)
+{
+  Header header;
+  header.Deserialize(src);
+
+  graph.m_mwms.reserve(header.m_numRegions);
+  graph.m_segments.reserve(header.m_numRoads);
+
+  std::map<uint32_t, NumMwmId> hashToMwmId;
+
+  numMwmIds->ForEachId([&](NumMwmId id) {
+    std::string const & region = numMwmIds->GetFile(id).GetName();
+    auto const & mwmNameHash = Hash(region);
+    // Triggering of this check in runtime means that the latest built mwm set differs from
+    // the previous one ("classic" mwm set which is constant for many years). The solution is to
+    // replace current hash function Hash() and rebuild World.mwm.
+    CHECK(hashToMwmId.emplace(mwmNameHash, id).second, (id, region, mwmNameHash));
+  });
+
+  std::set<uint32_t> mwmNameHashes;
+
+  for (size_t i = 0; i < header.m_numRegions; ++i)
+  {
+    auto const mwmNameHash = ReadPrimitiveFromSource<uint32_t>(src);
+    mwmNameHashes.emplace(mwmNameHash);
+  }
+
+  auto readVal = [&src]() {
+    return Uint32ToDouble(ReadPrimitiveFromSource<uint32_t>(src), SerDesVals::GetMin(),
+                          SerDesVals::GetMax(), SerDesVals::GetBitsCount());
+  };
+
+  auto readSegEnding = [&](CrossBorderSegmentEnding & ending) {
+    double const lat = readVal();
+    double const lon = readVal();
+    ending.m_point = LatLonWithAltitude(ms::LatLon(lat, lon), geometry::kDefaultAltitudeMeters);
+
+    NumMwmId index = ReadPrimitiveFromSource<uint16_t>(src);
+    CHECK_LESS(index, mwmNameHashes.size(), ());
+
+    auto it = mwmNameHashes.begin();
+    std::advance(it, index);
+
+    auto const & mwmHash = *it;
+    auto itHash = hashToMwmId.find(mwmHash);
+    CHECK(itHash != hashToMwmId.end(), (mwmHash));
+
+    ending.m_numMwmId = itHash->second;
+  };
+
+  for (size_t i = 0; i < header.m_numRoads; ++i)
+  {
+    RegionSegmentId segId = ReadPrimitiveFromSource<RegionSegmentId>(src);
+
+    CrossBorderSegment seg;
+
+    seg.m_weight = static_cast<double>(ReadPrimitiveFromSource<uint32_t>(src));
+    readSegEnding(seg.m_start);
+    readSegEnding(seg.m_end);
+
+    graph.AddCrossBorderSegment(segId, seg);
+  }
+}
+
+template <class Sink>
+void CrossBorderGraphSerializer::Header::Serialize(Sink & sink) const
+{
+  WriteToSink(sink, m_version);
+  WriteToSink(sink, m_numRegions);
+  WriteToSink(sink, m_numRoads);
+}
+
+template <class Source>
+void CrossBorderGraphSerializer::Header::Deserialize(Source & src)
+{
+  m_version = ReadPrimitiveFromSource<uint32_t>(src);
+  CHECK_EQUAL(m_version, kLatestVersionRoutingWorldSection, ("Unknown CrossRegionGraph version."));
+
+  m_numRegions = ReadPrimitiveFromSource<uint32_t>(src);
+  m_numRoads = ReadPrimitiveFromSource<uint32_t>(src);
+}
+}  // namespace routing

--- a/routing/routing_tests/CMakeLists.txt
+++ b/routing/routing_tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(
   bfs_tests.cpp
   checkpoint_predictor_test.cpp
   coding_test.cpp
+  cross_border_graph_tests.cpp
   cross_mwm_connector_test.cpp
   cumulative_restriction_test.cpp
   edge_estimator_tests.cpp
@@ -51,6 +52,8 @@ omim_link_libraries(
   map
   ge0
   routing
+  storage
+  mwm_diff
   platform_tests_support
   traffic
   routing_common
@@ -68,6 +71,7 @@ omim_link_libraries(
   opening_hours
   protobuf
   pugixml
+  bsdiff
   succinct
   stats_client
   icu

--- a/routing/routing_tests/cross_border_graph_tests.cpp
+++ b/routing/routing_tests/cross_border_graph_tests.cpp
@@ -1,0 +1,145 @@
+#include "testing/testing.hpp"
+
+#include "routing/cross_border_graph.hpp"
+
+#include "storage/routing_helpers.hpp"
+#include "storage/storage.hpp"
+
+#include "routing_common/num_mwm_id.hpp"
+
+#include "platform/platform.hpp"
+
+#include "coding/file_reader.hpp"
+#include "coding/file_writer.hpp"
+
+#include "geometry/distance_on_sphere.hpp"
+#include "geometry/latlon.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace routing
+{
+//  Test for serializing/deserializing of the chain of 4 points passing through 4 mwms:
+//  *-------------------------*-------------------------*-------------------------*
+//  p1                        p2                        p3                        p4
+
+std::pair<ms::LatLon, NumMwmId> GetCoordInRegion(double lat, double lon, std::string const & region,
+                                                 std::shared_ptr<NumMwmIds> numMwmIds)
+{
+  return {ms::LatLon(lat, lon), numMwmIds->GetId(platform::CountryFile(region))};
+}
+
+void FillGraphWithTestInfo(CrossBorderGraph & gaph, std::shared_ptr<NumMwmIds> numMwmIds)
+{
+  auto const [p1, id1] = GetCoordInRegion(50.88010, 4.41923, "Belgium_Flemish Brabant", numMwmIds);
+  auto const [p2, id2] = GetCoordInRegion(50.99043, 5.48125, "Belgium_Limburg", numMwmIds);
+  auto const [p3, id3] = GetCoordInRegion(50.88751, 5.92378, "Netherlands_Limburg", numMwmIds);
+  auto const [p4, id4] = GetCoordInRegion(
+      50.8734, 6.27417, "Germany_North Rhine-Westphalia_Regierungsbezirk Koln_Aachen", numMwmIds);
+
+  double constexpr avgSpeedMpS = 14.0;
+
+  CrossBorderSegment d12;
+  d12.m_weight = ms::DistanceOnEarth(p1, p2) / avgSpeedMpS;
+  d12.m_start = CrossBorderSegmentEnding(p1, id1);
+  d12.m_end = CrossBorderSegmentEnding(p2, id2);
+  gaph.m_segments.emplace(10, d12);
+
+  CrossBorderSegment d23;
+  d23.m_weight = ms::DistanceOnEarth(p2, p3) / avgSpeedMpS;
+  d23.m_start = CrossBorderSegmentEnding(p2, id2);
+  d23.m_end = CrossBorderSegmentEnding(p3, id3);
+  gaph.m_segments.emplace(20, d23);
+
+  CrossBorderSegment d34;
+  d34.m_weight = ms::DistanceOnEarth(p3, p4) / avgSpeedMpS;
+  d34.m_start = CrossBorderSegmentEnding(p3, id3);
+  d34.m_end = CrossBorderSegmentEnding(p4, id4);
+  gaph.m_segments.emplace(30, d34);
+
+  gaph.m_mwms.emplace(id1, std::vector<RegionSegmentId>{10});
+  gaph.m_mwms.emplace(id2, std::vector<RegionSegmentId>{10, 20});
+  gaph.m_mwms.emplace(id3, std::vector<RegionSegmentId>{20, 30});
+  gaph.m_mwms.emplace(id4, std::vector<RegionSegmentId>{30});
+}
+
+template <class T>
+T GetSorted(T const & cont)
+{
+  auto contSorted = cont;
+  std::sort(contSorted.begin(), contSorted.end());
+  return contSorted;
+}
+
+void TestEqualMwm(MwmIdToSegmentIds const & mwmIds1, MwmIdToSegmentIds const & mwmIds2)
+{
+  TEST_EQUAL(mwmIds1.size(), mwmIds2.size(), ());
+
+  for (auto const & [mwmId, segIds] : mwmIds1)
+  {
+    auto itMwmId = mwmIds2.find(mwmId);
+    TEST(itMwmId != mwmIds2.end(), ());
+    TEST_EQUAL(GetSorted(segIds), GetSorted(itMwmId->second), ());
+  }
+}
+
+void TestEqualSegments(CrossBorderSegments const & s1, CrossBorderSegments const & s2)
+{
+  TEST_EQUAL(s1.size(), s2.size(), ());
+
+  for (auto const & [segId1, data1] : s1)
+  {
+    auto itSegId = s2.find(segId1);
+    TEST(itSegId != s2.end(), ());
+
+    auto const & data2 = itSegId->second;
+
+    static double constexpr epsCoord = 1e-5;
+
+    TEST(base::AlmostEqualAbs(data1.m_start.m_point.GetLatLon(), data2.m_start.m_point.GetLatLon(),
+                              epsCoord),
+         ());
+    TEST(base::AlmostEqualAbs(data1.m_end.m_point.GetLatLon(), data2.m_end.m_point.GetLatLon(),
+                              epsCoord),
+         ());
+    TEST_EQUAL(static_cast<uint32_t>(std::ceil(data1.m_weight)),
+               static_cast<uint32_t>(std::ceil(data2.m_weight)), ());
+  }
+}
+
+UNIT_TEST(CrossBorderGraph_SerDes)
+{
+  std::string const fileName = "CrossBorderGraph_SerDes.test";
+
+  storage::Storage storage;
+  storage.RegisterAllLocalMaps(false /* enableDiffs */);
+  std::shared_ptr<NumMwmIds> numMwmIds = CreateNumMwmIds(storage);
+
+  CrossBorderGraph graph1;
+  FillGraphWithTestInfo(graph1, numMwmIds);
+
+  {
+    FilesContainerW cont(fileName, FileWriter::OP_WRITE_TRUNCATE);
+    auto writer = cont.GetWriter(ROUTING_WORLD_FILE_TAG);
+    CrossBorderGraphSerializer::Serialize(graph1, writer, numMwmIds);
+  }
+
+  uint64_t sizeBytes;
+  CHECK(GetPlatform().GetFileSizeByFullPath(fileName, sizeBytes), (fileName, sizeBytes));
+  LOG(LINFO, ("File size:", sizeBytes, "bytes"));
+
+  FilesContainerR cont(fileName);
+  auto src = std::make_unique<FilesContainerR::TReader>(cont.GetReader(ROUTING_WORLD_FILE_TAG));
+  ReaderSource<FilesContainerR::TReader> reader(*src);
+
+  CrossBorderGraph graph2;
+  CrossBorderGraphSerializer::Deserialize(graph2, reader, numMwmIds);
+
+  TestEqualMwm(graph1.m_mwms, graph2.m_mwms);
+  TestEqualSegments(graph1.m_segments, graph2.m_segments);
+}
+}  // namespace routing

--- a/xcode/routing/routing.xcodeproj/project.pbxproj
+++ b/xcode/routing/routing.xcodeproj/project.pbxproj
@@ -326,6 +326,8 @@
 		D5481E4E24BF4F70008FB1D8 /* mwm_hierarchy_handler.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D5481E4C24BF4F70008FB1D8 /* mwm_hierarchy_handler.hpp */; };
 		D5481E4F24BF4F70008FB1D8 /* mwm_hierarchy_handler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D5481E4D24BF4F70008FB1D8 /* mwm_hierarchy_handler.cpp */; };
 		D563401F2423816C00FDE20A /* guides_tests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D563401E2423816C00FDE20A /* guides_tests.cpp */; };
+		D57834C02562ED5F0020A420 /* cross_border_graph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D57834BE2562ED5F0020A420 /* cross_border_graph.cpp */; };
+		D57834C12562ED5F0020A420 /* cross_border_graph.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D57834BF2562ED5F0020A420 /* cross_border_graph.hpp */; };
 		D5C9497C2525C855001E45E2 /* directions_engine_helpers.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D5C9497A2525C854001E45E2 /* directions_engine_helpers.hpp */; };
 		D5C9497D2525C855001E45E2 /* directions_engine_helpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D5C9497B2525C855001E45E2 /* directions_engine_helpers.cpp */; };
 		F6C3A1B521AC298F0060EEC8 /* speed_camera_manager.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F6C3A1B321AC298E0060EEC8 /* speed_camera_manager.hpp */; };
@@ -621,6 +623,8 @@
 		D5481E4C24BF4F70008FB1D8 /* mwm_hierarchy_handler.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = mwm_hierarchy_handler.hpp; sourceTree = "<group>"; };
 		D5481E4D24BF4F70008FB1D8 /* mwm_hierarchy_handler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mwm_hierarchy_handler.cpp; sourceTree = "<group>"; };
 		D563401E2423816C00FDE20A /* guides_tests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = guides_tests.cpp; sourceTree = "<group>"; };
+		D57834BE2562ED5F0020A420 /* cross_border_graph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cross_border_graph.cpp; sourceTree = "<group>"; };
+		D57834BF2562ED5F0020A420 /* cross_border_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = cross_border_graph.hpp; sourceTree = "<group>"; };
 		D5C9497A2525C854001E45E2 /* directions_engine_helpers.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = directions_engine_helpers.hpp; sourceTree = "<group>"; };
 		D5C9497B2525C855001E45E2 /* directions_engine_helpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = directions_engine_helpers.cpp; sourceTree = "<group>"; };
 		F6C3A1B321AC298E0060EEC8 /* speed_camera_manager.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = speed_camera_manager.hpp; sourceTree = "<group>"; };
@@ -901,6 +905,8 @@
 		675343FA1A3F640D00A0A8C3 /* routing */ = {
 			isa = PBXGroup;
 			children = (
+				D57834BE2562ED5F0020A420 /* cross_border_graph.cpp */,
+				D57834BF2562ED5F0020A420 /* cross_border_graph.hpp */,
 				D52EF20125260E1500DFEB57 /* directions_engine.cpp */,
 				D5C9497B2525C855001E45E2 /* directions_engine_helpers.cpp */,
 				D5C9497A2525C854001E45E2 /* directions_engine_helpers.hpp */,
@@ -1184,6 +1190,7 @@
 				56099E2B1CC7C97D00A7772A /* turn_candidate.hpp in Headers */,
 				405F48DC1F6AD01C005BA81A /* routing_result.hpp in Headers */,
 				56FEAA6E219E8A610073DF5F /* maxspeeds_serialization.hpp in Headers */,
+				D57834C12562ED5F0020A420 /* cross_border_graph.hpp in Headers */,
 				4065EA801F824A6C0094DEF3 /* transit_world_graph.hpp in Headers */,
 				44B284C823F5A21300A3FBB7 /* opening_hours_serdes.hpp in Headers */,
 				44E5574A2136EEC900B01439 /* speed_camera_ser_des.hpp in Headers */,
@@ -1426,6 +1433,7 @@
 				441CC8C623ACF42C008B9A49 /* segment.cpp in Sources */,
 				44AE4A12214FBB8E006321F5 /* speed_camera.cpp in Sources */,
 				674F9BCA1B0A580E00704FFA /* async_router.cpp in Sources */,
+				D57834C02562ED5F0020A420 /* cross_border_graph.cpp in Sources */,
 				0C5F5D221E798B0400307B98 /* cross_mwm_connector.cpp in Sources */,
 				0C81E1531F02589800DC66DF /* traffic_stash.cpp in Sources */,
 				0CF5E8AA1E8EA7A1001ED497 /* coding_test.cpp in Sources */,


### PR DESCRIPTION
Мы хотим добавить в World mwm новую секцию для роутинга, из которой будем читать данные об основных дорогах между mwm. По графу из этих "дорог" параллельно нашему обычному роутингу будет запускаться второй поток, который найдет отсутствующие мвм, по которым предположительно проходит маршрут. Запуск потока реализован в #13922 

Это - реквест с классом - графом дорог, (де)сериализацией для него и тестами. Дорога представляет собой координаты начала и конца, привязанные к ним номера мвм и вес дороги (смотри иллюстрацию в реквесте #13922).
@bykoianko Классы с данными для роутинга в этом реквесте слегка отличаются от тех, что в #13922 (смысл тот же, исполнение чуть более инкапсулярное). Поэтому предлагаю сначала мержить этот реквест, а потом - предыдущий.

@maksimandrianov Сериализация секции в World.mwm (генератор) будет в следующем реквесте.
