### PR TITLE
[android]: fix for crash on bookmarksCategory unmarshalling during ap restoration

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/BaseBookmarkCategoriesFragment.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BaseBookmarkCategoriesFragment.java
@@ -294,14 +294,7 @@ public abstract class BaseBookmarkCategoriesFragment extends BaseMwmRecyclerFrag
   public void onItemClick(@NonNull View v, @NonNull BookmarkCategory category)
   {
     mSelectedCategory = category;
-    startActivityForResult(makeBookmarksListIntent(category), REQ_CODE_DELETE_CATEGORY);
-  }
-
-  @NonNull
-  private Intent makeBookmarksListIntent(@NonNull BookmarkCategory category)
-  {
-    return new Intent(getActivity(), BookmarkListActivity.class)
-        .putExtra(BookmarksListFragment.EXTRA_CATEGORY, category);
+    BookmarkListActivity.startForResult(requireActivity(), category);
   }
 
   protected void onShareActionSelected(@NonNull BookmarkCategory category)

--- a/android/src/com/mapswithme/maps/bookmarks/BookmarkListActivity.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarkListActivity.java
@@ -1,7 +1,9 @@
 package com.mapswithme.maps.bookmarks;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
@@ -12,6 +14,8 @@ import com.mapswithme.maps.base.BaseToolbarActivity;
 import com.mapswithme.maps.bookmarks.data.BookmarkCategory;
 import com.mapswithme.maps.bookmarks.data.BookmarkManager;
 import com.mapswithme.util.ThemeUtils;
+
+import static com.mapswithme.maps.bookmarks.BookmarksListFragment.EXTRA_BUNDLE;
 
 public class BookmarkListActivity extends BaseToolbarActivity
 {
@@ -58,8 +62,25 @@ public class BookmarkListActivity extends BaseToolbarActivity
 
   static void startForResult(@NonNull Activity activity, @NonNull BookmarkCategory category)
   {
-    Intent intent = new Intent(activity, BookmarkListActivity.class);
-    intent.putExtra(BookmarksListFragment.EXTRA_CATEGORY, category);
-    activity.startActivityForResult(intent, BaseBookmarkCategoriesFragment.REQ_CODE_DELETE_CATEGORY);
+    activity.startActivityForResult(getStartIntent(activity, category),
+                                    BaseBookmarkCategoriesFragment.REQ_CODE_DELETE_CATEGORY);
+  }
+
+  @NonNull
+  static Intent getStartIntent(@NonNull Context context,
+                                        @NonNull BookmarkCategory bookmarkCategory)
+  {
+    Intent intent = new Intent(context, BookmarkListActivity.class);
+    return wrapDataToBundle(intent, bookmarkCategory);
+  }
+
+  @NonNull
+  private static Intent wrapDataToBundle(@NonNull Intent intent,
+                                                  @NonNull BookmarkCategory bookmarkCategory)
+  {
+    Bundle bundle = new Bundle();
+    bundle.putParcelable(BookmarksListFragment.EXTRA_CATEGORY, bookmarkCategory);
+    intent.putExtra(EXTRA_BUNDLE, bundle);
+    return intent;
   }
 }

--- a/android/src/com/mapswithme/maps/bookmarks/BookmarksListFragment.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarksListFragment.java
@@ -65,6 +65,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<BookmarkListA
 {
   public static final String TAG = BookmarksListFragment.class.getSimpleName();
   public static final String EXTRA_CATEGORY = "bookmark_category";
+  public static final String EXTRA_BUNDLE = "bookmark_bundle";
 
   @SuppressWarnings("NullableProblems")
   @NonNull
@@ -131,7 +132,8 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<BookmarkListA
   {
     Bundle args = getArguments();
     BookmarkCategory category;
-    if (args == null || ((category = args.getParcelable(EXTRA_CATEGORY))) == null)
+    if (args == null || (args.getBundle(EXTRA_BUNDLE) == null) ||
+        ((category = args.getBundle(EXTRA_BUNDLE).getParcelable(EXTRA_CATEGORY))) == null)
       throw new IllegalArgumentException("Category not exist in bundle");
 
     return category;
@@ -152,8 +154,7 @@ public class BookmarksListFragment extends BaseMwmRecyclerFragment<BookmarkListA
     mBookmarkCollectionAdapter = new BookmarkCollectionAdapter(getCategoryOrThrow(),
                                                                mCategoryItems, mCollectionItems);
     mBookmarkCollectionAdapter.setOnClickListener((v, item) -> {
-      Intent intent = new Intent(getActivity(), BookmarkListActivity.class)
-          .putExtra(BookmarksListFragment.EXTRA_CATEGORY, item);
+      Intent intent = BookmarkListActivity.getStartIntent(requireContext(), item);
 
       final boolean isCategory = BookmarkManager.INSTANCE.getCompilationType(item.getId()) ==
                                  BookmarkManager.CATEGORY;


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-14805
Проблема была в том, что при восстановлении стейта Активити из ее интента перекладываются данные в бандл, но к этому моменту в classLoader содержатся только андроидные классы, а пользовательские типы добавляются системой туда позднее