### PR TITLE
[android] show convert bookmarks dialog only one time

### DIFF
--- a/android/src/com/mapswithme/maps/bookmarks/BaseBookmarkCategoriesFragment.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BaseBookmarkCategoriesFragment.java
@@ -56,10 +56,6 @@ public abstract class BaseBookmarkCategoriesFragment extends BaseMwmRecyclerFrag
   private BookmarkCategory mSelectedCategory;
   @Nullable
   private CategoryEditor mCategoryEditor;
-  @Nullable
-  private KmlImportController mKmlImportController;
-  @NonNull
-  private Runnable mImportKmlTask = new ImportKmlTask();
   @SuppressWarnings("NullableProblems")
   @NonNull
   private BookmarkManager.BookmarksCatalogListener mCatalogListener;
@@ -110,7 +106,7 @@ public abstract class BaseBookmarkCategoriesFragment extends BaseMwmRecyclerFrag
 
   protected void onPrepareControllers(@NonNull View view)
   {
-    mKmlImportController = new KmlImportController(getActivity(), this);
+    // No op
   }
 
   protected void updateLoadingPlaceholder()
@@ -131,8 +127,6 @@ public abstract class BaseBookmarkCategoriesFragment extends BaseMwmRecyclerFrag
     BookmarkManager.INSTANCE.addLoadingListener(this);
     BookmarkManager.INSTANCE.addSharingListener(this);
     BookmarkManager.INSTANCE.addCatalogListener(mCatalogListener);
-    if (mKmlImportController != null)
-      mKmlImportController.onStart();
   }
 
   @Override
@@ -142,8 +136,6 @@ public abstract class BaseBookmarkCategoriesFragment extends BaseMwmRecyclerFrag
     BookmarkManager.INSTANCE.removeLoadingListener(this);
     BookmarkManager.INSTANCE.removeSharingListener(this);
     BookmarkManager.INSTANCE.removeCatalogListener(mCatalogListener);
-    if (mKmlImportController != null)
-      mKmlImportController.onStop();
   }
 
   @Override
@@ -152,8 +144,6 @@ public abstract class BaseBookmarkCategoriesFragment extends BaseMwmRecyclerFrag
     super.onResume();
     updateLoadingPlaceholder();
     getAdapter().notifyDataSetChanged();
-    if (!BookmarkManager.INSTANCE.isAsyncBookmarksLoadingInProgress())
-      mImportKmlTask.run();
   }
 
   @Override
@@ -234,19 +224,12 @@ public abstract class BaseBookmarkCategoriesFragment extends BaseMwmRecyclerFrag
   {
     updateLoadingPlaceholder();
     getAdapter().notifyDataSetChanged();
-    mImportKmlTask.run();
   }
 
   @Override
   public void onBookmarksFileLoaded(boolean success)
   {
     // Do nothing here.
-  }
-
-  private void importKml()
-  {
-    if (mKmlImportController != null)
-      mKmlImportController.importKml();
   }
 
   @Override
@@ -373,20 +356,6 @@ public abstract class BaseBookmarkCategoriesFragment extends BaseMwmRecyclerFrag
     void commit(@NonNull String newName);
   }
 
-  private class ImportKmlTask implements Runnable
-  {
-    private boolean alreadyDone;
-
-    @Override
-    public void run()
-    {
-      if (alreadyDone)
-        return;
-
-      importKml();
-      alreadyDone = true;
-    }
-  }
 
   protected enum MenuItemClickProcessorWrapper
   {

--- a/android/src/com/mapswithme/maps/bookmarks/BookmarkCategoriesFragment.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarkCategoriesFragment.java
@@ -24,7 +24,6 @@ public class BookmarkCategoriesFragment extends BaseBookmarkCategoriesFragment
   @Override
   protected void onPrepareControllers(@NonNull View view)
   {
-    super.onPrepareControllers(view);
     Authorizer authorizer = new Authorizer(this);
     BookmarkBackupView backupView = view.findViewById(R.id.backup);
 

--- a/android/src/com/mapswithme/maps/bookmarks/BookmarksPageFactory.java
+++ b/android/src/com/mapswithme/maps/bookmarks/BookmarksPageFactory.java
@@ -1,6 +1,7 @@
 package com.mapswithme.maps.bookmarks;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import android.text.TextUtils;
 
@@ -93,7 +94,7 @@ public enum BookmarksPageFactory
   }
 
   @NonNull
-  public abstract Fragment instantiateFragment();
+  protected abstract Fragment instantiateFragment();
 
   public abstract int getTitle();
 

--- a/android/src/com/mapswithme/maps/bookmarks/CachedBookmarkCategoriesFragment.java
+++ b/android/src/com/mapswithme/maps/bookmarks/CachedBookmarkCategoriesFragment.java
@@ -194,6 +194,13 @@ public class CachedBookmarkCategoriesFragment extends BaseBookmarkCategoriesFrag
     }
   }
 
+  @Override
+  public void onFinishKmlImport()
+  {
+    updateLoadingPlaceholder();
+    super.onFinishKmlImport();
+  }
+
   private class BookmarkCategoriesCatalogListener implements BookmarkManager.BookmarksCatalogListener
   {
     @Override


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-8244
Проблема была в том, что логика отображения диалога оказалась в базовом классе двух экранов вьюпейджера, соответственно onResume вызывался дважды. Перенес эту логику в рутовый фрагмент вьюпейджера чтобы избавиться от двойного вызова
Пришлось добавить кэширование экранов в адаптере вьюпейджера, до этого на каждый вызов getItem создавался новый фрагмент, что с одной стороны не очень эффективно, а с другой не позволяло нотифицировать страницы вьюпейджера о том, что завершилась конвертация