### PR TITLE
[android] Edit visibility done button in edit category fragment.

### DIFF
--- a/android/src/com/mapswithme/maps/ugc/routes/BaseEditUserBookmarkCategoryFragment.java
+++ b/android/src/com/mapswithme/maps/ugc/routes/BaseEditUserBookmarkCategoryFragment.java
@@ -106,8 +106,7 @@ public abstract class BaseEditUserBookmarkCategoryFragment extends BaseMwmToolba
   public void onPrepareOptionsMenu(Menu menu)
   {
     super.onPrepareOptionsMenu(menu);
-    MenuItem item = menu.findItem(R.id.done);
-    item.setVisible(mEditText.getEditableText().length() > 0);
+    setMenuVisibility(mEditText.getEditableText().length() > 0);
   }
 
   @Override
@@ -168,8 +167,7 @@ public abstract class BaseEditUserBookmarkCategoryFragment extends BaseMwmToolba
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count)
     {
-      if (s.length() == 0 || s.length() == 1)
-        getActivity().invalidateOptionsMenu();
+      setMenuVisibility(s.length() > 1);
     }
 
     @Override


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-15294

Тут пришлось изменить, так как если спрятать элемент при переходе на экран описания(где описание пустое), то в дальнейшем отображать так же нужно элемент, а это лишняя операция поиска элемента в одноэлементном списке.
    MenuItem item = menu.findItem(R.id.done);
    item.setVisible(mEditText.getEditableText().length() > 0);