### PR TITLE
[android] Fixed showing discount in pp.

### DIFF
--- a/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
+++ b/android/src/com/mapswithme/maps/widget/placepage/PlacePageView.java
@@ -1159,6 +1159,7 @@ public class PlacePageView extends NestedScrollViewClickFixed
       mMapObject = mapObject;
       NetworkPolicy policy = NetworkPolicy.newInstance(NetworkPolicy.getCurrentNetworkUsageStatus());
       refreshViews(policy);
+      processSponsored(policy);
       if (listener != null)
       {
         listener.onSetMapObjectComplete(policy, true);
@@ -1249,7 +1250,6 @@ public class PlacePageView extends NestedScrollViewClickFixed
       LOGGER.e(TAG, "A place page views cannot be refreshed, mMapObject is null");
       return;
     }
-
     refreshPreview(mMapObject, null);
     refreshDetails(mMapObject);
     refreshHotelDetailViews(policy);


### PR DESCRIPTION
https://jira.mail.ru/browse/MAPSME-14497

Лучше воспроизводить с стр из комментариев.

Проблема заключалась в том, что когда после перехода из поиска мы сворачиваем pp, потом в метод refreshPreview для дискаунт приходит null и цена никак не отображается. Вставила такую проверку, потому что потом колобке все равно вызовет refreshPreview и в итоге цена запросится.

Сам класс довольно большой, поэтому вопрос: это ничего в дальнейшем не сломает? Я повестила, крепей и аномалий не словила.
