### PR TITLE
[generator] Better determination if building has parts

### DIFF
--- a/generator/boost_helpers.hpp
+++ b/generator/boost_helpers.hpp
@@ -10,12 +10,13 @@ namespace generator
 {
 namespace boost_helpers
 {
-using BoostPoint = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>;
-using BoostPolygon = boost::geometry::model::polygon<BoostPoint>;
 
-template <typename BoostPoint, typename BoostGeometry, typename FbGeometry>
+template <typename BoostGeometry, typename FbGeometry>
 void FillBoostGeometry(BoostGeometry & geometry, FbGeometry const & fbGeometry)
 {
+  using BoostPoint = typename boost::geometry::point_type<BoostGeometry>::type;
+
+  geometry.clear();
   geometry.reserve(fbGeometry.size());
   for (auto const & p : fbGeometry)
     boost::geometry::append(geometry, BoostPoint{p.x, p.y});
@@ -24,16 +25,17 @@ void FillBoostGeometry(BoostGeometry & geometry, FbGeometry const & fbGeometry)
 template <typename BoostPolygon>
 void FillPolygon(BoostPolygon & polygon, feature::FeatureBuilder const & fb)
 {
-  using BoostPoint = typename BoostPolygon::point_type;
   auto const & fbGeometry = fb.GetGeometry();
   CHECK(!fbGeometry.empty(), ());
-  auto it = std::begin(fbGeometry);
-  FillBoostGeometry<BoostPoint>(polygon.outer(), *it);
+
+  polygon.clear();
+  FillBoostGeometry(polygon.outer(), *fbGeometry.begin());
   polygon.inners().resize(fbGeometry.size() - 1);
-  int i = 0;
-  ++it;
-  for (; it != std::end(fbGeometry); ++it)
-    FillBoostGeometry<BoostPoint>(polygon.inners()[i++], *it);
+
+  size_t i = 0;
+
+  for (auto it = std::next(fbGeometry.begin()); it != fbGeometry.end(); ++it)
+    FillBoostGeometry(polygon.inners()[i++], *it);
 
   boost::geometry::correct(polygon);
 }

--- a/generator/final_processor_country.hpp
+++ b/generator/final_processor_country.hpp
@@ -48,6 +48,7 @@ private:
   void AddIsolines();
   void DropProhibitedSpeedCameras();
   void Finish();
+  void ProcessBuildingParts();
 
   bool IsCountry(std::string const & filename);
 

--- a/generator/hierarchy.cpp
+++ b/generator/hierarchy.cpp
@@ -20,7 +20,6 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/register/point.hpp>
 #include <boost/geometry/geometries/register/ring.hpp>
-#include <boost/geometry/multi/geometries/register/multi_point.hpp>
 
 BOOST_GEOMETRY_REGISTER_POINT_2D(m2::PointD, double, boost::geometry::cs::cartesian, x, y);
 BOOST_GEOMETRY_REGISTER_RING(std::vector<m2::PointD>);

--- a/generator/osm2type.cpp
+++ b/generator/osm2type.cpp
@@ -720,8 +720,6 @@ void PostprocessElement(OsmElement * p, FeatureBuilderParams & params)
       {"wheelchair", "designated",
        [&params] { params.AddType(types.Get(CachedTypes::Type::WheelchairYes)); }},
       {"wifi", "~", [&params] { params.AddType(types.Get(CachedTypes::Type::Wlan)); }},
-      {"building:part", "no", [&params] { params.AddType(types.Get(CachedTypes::Type::HasParts)); }},
-      {"building:parts", "~", [&params] { params.AddType(types.Get(CachedTypes::Type::HasParts)); }},
   });
 
   bool highwayDone = false;

--- a/generator/relation_tags.cpp
+++ b/generator/relation_tags.cpp
@@ -98,12 +98,7 @@ void RelationTagsWay::Process(RelationElement const & e)
   }
 
   if (type == "building")
-  {
-    // If this way has "outline" role, add [building=has_parts] type.
-    if (e.GetWayRole(m_current->m_id) == "outline")
-      Base::AddCustomTag({"building", "has_parts"});
     return;
-  }
 
   bool const isBoundary = (type == "boundary") && IsAcceptBoundary(e);
   bool const processAssociatedStreet = type == "associatedStreet" &&


### PR DESCRIPTION
Presently, a building feature is marked as _has_parts_ if it has _building:parts=yes/vertical/horizontal/..._ tag, or if it's a member of a _type=building_ relation with _outline_ role. Such building won't be rendered in the hope that _building:part_ features would be rendered instead. But both of these methods are not reliable, since:
- a building can have no _building:parts=yes_ tag when it is really cut into parts (very often case)
- a building can have _building:parts=yes_ tag without actually having parts inside it (rare but also occur)
- _type=building_ relation may be broken and not reflect real building-parts relationship (also, currently only ways that are _outline_ members of _building_ relations are considered as buildings to be marked with _has_parts_ property; multipolygon contours  are not)
- quite often, only small fraction of a building footprint is covered by parts. In such case, if rely on current _has_parts_ determination procedure, the building won't be rendered somehow correctly. Apparently many mappers believe that the rest of the footprint area should be rendered with properties (primarily, the height) taken from the building, while OSM **Simple 3D buildings** wiki page says that the whole building footprint should be covered by parts. 

This PR suggests to ignore _type=building_ relations and _building:parts=yes/..._ tag, and to mark buildings with 'has_parts' label if its contour is covered with parts at least by 90%.

**The following example** illustrates the situation when not the whole building contour is covered by parts.

How building looks like in reality:
![Building-nii-correct](https://user-images.githubusercontent.com/35913079/102206869-4ff43b80-3ede-11eb-8f91-88abe33ee42c.png)

How it is rendered if only prominent building parts are mapped, and there is _building:parts=yes_ tag or _building_ relation, before PR:
![Building-nii_before_PR](https://user-images.githubusercontent.com/35913079/102207054-89c54200-3ede-11eb-8248-69a046ee6e02.png)

How it is rendered if only prominent building parts are mapped, regardless of _building:parts_ tag or _building_ relation, after PR (building has _building:levels=2_ tag which is the maximum value among all parts. Had it no _building:levels_ tag, it would render as on the first picture):
![Building-nii_after_PR](https://user-images.githubusercontent.com/35913079/102207085-93e74080-3ede-11eb-9690-ed470aa881e6.png)


**Another problem** that the PR solves:
currently, two twin buildings consisting of two parts of different height are rendered correctly/incorrectly depending on _building:parts=yes_ tag presence/absence. After the PR both buildings would be rendered correctly, like the one to the right.

<img width="273" alt="building_parts-1" src="https://user-images.githubusercontent.com/35913079/102346083-5f8f8500-3faf-11eb-938e-be614dd87bf2.png">
