### PR TITLE
[DNM][coding][indexer][generator] Compress geometry.

### DIFF
--- a/coding/geometry_coding.hpp
+++ b/coding/geometry_coding.hpp
@@ -134,16 +134,23 @@ public:
   }
 
   template <typename SourceT>
-  void Load(SourceT & src)
+  void Load(SourceT & src, bool haveLimitRect)
   {
     uint32_t const coordBits = ReadVarUint<uint32_t>(src);
     ASSERT_LESS(coordBits, 32, ());
     auto const basePoint = ReadVarUint<uint64_t>(src);
-    auto const leftBottom =
-        PointUToPointD(Uint64ToPointUObsolete(ReadVarUint<uint64_t>(src)), kPointCoordBits);
-    auto const rightTop =
-        PointUToPointD(Uint64ToPointUObsolete(ReadVarUint<uint64_t>(src)), kPointCoordBits);
-    *this = GeometryCodingParams(coordBits, basePoint, m2::RectD(leftBottom, rightTop));
+    if (haveLimitRect)
+    {
+      auto const leftBottom =
+          PointUToPointD(Uint64ToPointUObsolete(ReadVarUint<uint64_t>(src)), kPointCoordBits);
+      auto const rightTop =
+          PointUToPointD(Uint64ToPointUObsolete(ReadVarUint<uint64_t>(src)), kPointCoordBits);
+      *this = GeometryCodingParams(coordBits, basePoint, m2::RectD(leftBottom, rightTop));
+    }
+    else
+    {
+      *this = GeometryCodingParams(coordBits, basePoint);
+    }
   }
 
 private:

--- a/coding/point_coding.hpp
+++ b/coding/point_coding.hpp
@@ -8,9 +8,7 @@
 
 uint8_t constexpr kPointCoordBits = 30;
 
-uint8_t constexpr kFeatureSorterPointCoordBits = 27;
-
-// The absolute precision of the point encoding in the mwm files.
+// The absolute precision of the point encoding in some mwm file sections.
 // If both x and y coordinates of two points lie within |kMwmPointAccuracy| of one
 // another we consider the points equal. In other words, |kMwmPointAccuracy| may
 // be used as the eps value for both x and y in Point::EqualDxDy, base::AlmostEqualAbs and such.
@@ -28,12 +26,8 @@ uint8_t constexpr kFeatureSorterPointCoordBits = 27;
 // 1 meter difference on the equator and we do not expect most OSM points to be mapped
 // with better precision.
 //
-// todo(@m) By this argument, it seems that 1e-6 is a better choice.
-//
-// Note. generator/feature_sorter.cpp uses |kFeatureSorterPointCoordBits|,
-// effectively overriding |kPointCoordBits|. Presumably it does so to guarantee a maximum of
-// 4 bytes in the varint encoding, (27+1 sign(?) bit) / 7 = 4.
-// todo(@m) Clarify how kPointCoordBits and kFeatureSorterPointCoordBits are related.
+// Note. Most of geometry inside features, geomX and trgX sections is saved with CoordBits which
+// depends on mwm size and guaranties kMwmPointAccuracy. See GetCoordBits(limitRect, accuracy).
 double constexpr kMwmPointAccuracy = 1e-5;
 
 uint32_t DoubleToUint32(double x, double min, double max, uint8_t coordBits);

--- a/generator/centers_table_builder.cpp
+++ b/generator/centers_table_builder.cpp
@@ -52,7 +52,7 @@ bool BuildCentersTableFromDataFile(std::string const & filename, bool forceRebui
       feature::DataHeader const header(rcont);
       FeaturesVector const features(rcont, header, table.get());
 
-      builder.SetGeometryParams(header.GetBounds());
+      builder.SetGeometryCodingParams(header.GetDefGeometryCodingParams());
       features.ForEach([&](FeatureType & ft, uint32_t featureId) {
         builder.Put(featureId, feature::GetCenter(ft));
       });

--- a/generator/feature_helpers.cpp
+++ b/generator/feature_helpers.cpp
@@ -48,6 +48,7 @@ bool CalculateMidPoints::operator()(m2::PointD const & p)
   m_midAll += p;
   ++m_locCount;
   ++m_allCount;
+  m_limitRect.Add(p);
   return true;
 }
 

--- a/generator/feature_helpers.hpp
+++ b/generator/feature_helpers.hpp
@@ -1,14 +1,15 @@
 #pragma once
 
+#include "indexer/feature_data.hpp"
+#include "indexer/feature_visibility.hpp"
+#include "indexer/scales.hpp"
+
 #include "coding/geometry_coding.hpp"
 
 #include "geometry/parametrized_segment.hpp"
 #include "geometry/point2d.hpp"
+#include "geometry/rect2d.hpp"
 #include "geometry/simplification.hpp"
-
-#include "indexer/feature_data.hpp"
-#include "indexer/feature_visibility.hpp"
-#include "indexer/scales.hpp"
 
 #include "base/assert.hpp"
 #include "base/math.hpp"
@@ -37,6 +38,7 @@ public:
   bool operator()(m2::PointD const & p);
 
   m2::PointD GetCenter() const;
+  m2::RectD const & GetLimitRect() const { return m_limitRect; }
   std::vector<CellAndOffset> const & GetVector() const { return m_vec; }
 
   void Sort();
@@ -44,6 +46,7 @@ public:
 private:
   m2::PointD m_midLoc;
   m2::PointD m_midAll;
+  m2::RectD m_limitRect;
   size_t m_locCount = 0;
   size_t m_allCount = 0;
   uint8_t m_coordBits = serial::GeometryCodingParams().GetCoordBits();

--- a/generator/generator_tests/speed_cameras_test.cpp
+++ b/generator/generator_tests/speed_cameras_test.cpp
@@ -70,7 +70,7 @@ string const kOsmIdsToFeatureIdsName = "osm_ids_to_feature_ids" OSM2FEATURE_FILE
 string const kIntermediateFileName = "intermediate_data";
 string const kOsmFileName = "town" OSM_DATA_FILE_EXTENSION;
 
-double constexpr kCoefEqualityEpsilonM = 1e-5;
+double constexpr kCoefEqualityEpsilon = 1e-5;
 
 // Pair of featureId and segmentId.
 using routing::SegmentCoord;
@@ -115,7 +115,7 @@ vector<CameraMapItem> UnpackMapToVector(CameraMap const & cameraMap)
   return result;
 }
 
-bool CheckCameraMapsEquality(CameraMap const & lhs, CameraMap const & rhs)
+bool CheckCameraMapsEquality(CameraMap const & lhs, CameraMap const & rhs, double epsilon)
 {
   if (lhs.size() != rhs.size())
     return false;
@@ -129,7 +129,7 @@ bool CheckCameraMapsEquality(CameraMap const & lhs, CameraMap const & rhs)
     // It can differ on jenknins and local computer.
     if (!(vectorL[i].first.m_segmentId == vectorR[i].first.m_segmentId &&
           vectorL[i].second.m_maxSpeedKmPH == vectorR[i].second.m_maxSpeedKmPH &&
-          base::AlmostEqualAbs(vectorL[i].second.m_coef, vectorR[i].second.m_coef, kCoefEqualityEpsilonM)))
+          base::AlmostEqualAbs(vectorL[i].second.m_coef, vectorR[i].second.m_coef, epsilon)))
     {
       LOG(LINFO, ("These should be equals:",
                   "sId:", vectorL[i].first.m_segmentId, vectorR[i].first.m_segmentId,
@@ -142,7 +142,8 @@ bool CheckCameraMapsEquality(CameraMap const & lhs, CameraMap const & rhs)
   return true;
 }
 
-void TestSpeedCameraSectionBuilding(string const & osmContent, CameraMap const & answer)
+void TestSpeedCameraSectionBuilding(string const & osmContent, CameraMap const & answer,
+                                    double epsilon)
 {
   GetStyleReader().SetCurrentStyle(MapStyleMerged);
   classificator::Load();
@@ -220,7 +221,8 @@ void TestSpeedCameraSectionBuilding(string const & osmContent, CameraMap const &
   BuildCamerasInfo(mwmFullPath, camerasFilename, osmToFeatureFilename);
 
   CameraMap const cameras = LoadSpeedCameraFromMwm(mwmFullPath);
-  TEST(CheckCameraMapsEquality(answer, cameras), ("Test answer and parsed cameras are differ!"));
+  TEST(CheckCameraMapsEquality(answer, cameras, epsilon),
+       ("Test answer and parsed cameras are differ!"));
 }
 
 // Next unit tests check building of speed camera section in mwm.
@@ -241,7 +243,7 @@ UNIT_TEST(SpeedCameraGenerationTest_Empty)
   )";
 
   CameraMap const answer = {};
-  TestSpeedCameraSectionBuilding(osmContent, answer);
+  TestSpeedCameraSectionBuilding(osmContent, answer, kCoefEqualityEpsilon);
 }
 
 UNIT_TEST(SpeedCameraGenerationTest_CameraIsOnePointOfFeature_1)
@@ -271,7 +273,7 @@ UNIT_TEST(SpeedCameraGenerationTest_CameraIsOnePointOfFeature_1)
   CameraMap const answer = {
     {SegmentCoord(0, 0), std::vector<RouteSegment::SpeedCamera>{{0, 100}}}
   };
-  TestSpeedCameraSectionBuilding(osmContent, answer);
+  TestSpeedCameraSectionBuilding(osmContent, answer, kCoefEqualityEpsilon);
 }
 
 UNIT_TEST(SpeedCameraGenerationTest_CameraIsOnePointOfFeature_2)
@@ -304,7 +306,7 @@ UNIT_TEST(SpeedCameraGenerationTest_CameraIsOnePointOfFeature_2)
   CameraMap const answer = {
     {SegmentCoord(0, 1), std::vector<RouteSegment::SpeedCamera>{{0, 100}}}
   };
-  TestSpeedCameraSectionBuilding(osmContent, answer);
+  TestSpeedCameraSectionBuilding(osmContent, answer, kCoefEqualityEpsilon);
 }
 
 UNIT_TEST(SpeedCameraGenerationTest_CameraIsOnePointOfFeature_3)
@@ -337,7 +339,7 @@ UNIT_TEST(SpeedCameraGenerationTest_CameraIsOnePointOfFeature_3)
   CameraMap const answer = {
     {SegmentCoord(0, 1), std::vector<RouteSegment::SpeedCamera>{{1, 100}}}
   };
-  TestSpeedCameraSectionBuilding(osmContent, answer);
+  TestSpeedCameraSectionBuilding(osmContent, answer, kCoefEqualityEpsilon);
 }
 
 UNIT_TEST(SpeedCameraGenerationTest_CameraIsOnePointOfFeature_4)
@@ -394,7 +396,7 @@ UNIT_TEST(SpeedCameraGenerationTest_CameraIsOnePointOfFeature_4)
     {SegmentCoord(0, 1), std::vector<RouteSegment::SpeedCamera>{{1, 100}}},
     {SegmentCoord(1, 1), std::vector<RouteSegment::SpeedCamera>{{0, 100}}}
   };
-  TestSpeedCameraSectionBuilding(osmContent, answer);
+  TestSpeedCameraSectionBuilding(osmContent, answer, kCoefEqualityEpsilon);
 }
 
 UNIT_TEST(SpeedCameraGenerationTest_CameraIsNearFeature_1)
@@ -420,17 +422,21 @@ UNIT_TEST(SpeedCameraGenerationTest_CameraIsNearFeature_1)
   // Geometry:
   // Feature number 0: <node>--------<node>
   //                             ^___ somewhere here camera, but it is not the point of segment.
-  //                                  We add it with coef close to 0.5 because of points' coords (lat, lon).
-  //                                  Coef was calculated by this program and checked by eye.
+  //                                  We add it with coef close to 0.5 because of points' coords
+  //                                  (lat, lon). Coef was calculated by this program and checked by
+  //                                  eye.
   // Result:
-  // {(0, 0), (0.486934, 100)} - featureId - 0, segmentId - 0,
-  //                             coef - position on segment (at the half of segment) ~ 0.486934,
+  // {(0, 0), (0.5, 100)} - featureId - 0, segmentId - 0,
+  //                             coef - position on segment (at the half of segment) - 0.5,
   //                             maxSpeed - 100.
 
+  auto epsilon = mercator::DistanceOnEarth({0, 0}, {kMwmPointAccuracy, kMwmPointAccuracy}) /
+                 mercator::DistanceOnEarth(mercator::FromLatLon(55.7793100, 37.3699100),
+                                           mercator::FromLatLon(55.7793300, 37.3699300));
+  epsilon = base::Clamp(epsilon, 0.0, 1.0);
   CameraMap const answer = {
-    {SegmentCoord(0, 0), std::vector<RouteSegment::SpeedCamera>{{0.48801310, 100}}}
-  };
-  TestSpeedCameraSectionBuilding(osmContent, answer);
+      {SegmentCoord(0, 0), std::vector<RouteSegment::SpeedCamera>{{0.5, 100}}}};
+  TestSpeedCameraSectionBuilding(osmContent, answer, epsilon);
 }
 
 UNIT_TEST(SpeedCameraGenerationTest_CameraIsNearFeature_2)
@@ -458,14 +464,18 @@ UNIT_TEST(SpeedCameraGenerationTest_CameraIsNearFeature_2)
   //                           ^___ somewhere here camera, but it is not the point of segment.
   //                                Coef was calculated by this program and checked by eye.
   // Result:
-  // {(0, 0), (0.229410536, 100)} - featureId - 0, segmentId - 0,
-  //                                coef - position on segment (at the half of segment) ~ 0.2294105,
+  // {(0, 0), (0.25, 100)} - featureId - 0, segmentId - 0,
+  //                                coef - position on segment - 0.25,
   //                                maxSpeed - 100.
+  auto epsilon = mercator::DistanceOnEarth({0, 0}, {kMwmPointAccuracy, kMwmPointAccuracy}) /
+                 mercator::DistanceOnEarth(mercator::FromLatLon(55.7793100, 37.3699100),
+                                           mercator::FromLatLon(55.7793300, 37.3699300));
+  epsilon = base::Clamp(epsilon, 0.0, 1.0);
 
   CameraMap const answer = {
-    {SegmentCoord(0, 0), std::vector<RouteSegment::SpeedCamera>{{0.2289881, 100}}}
+    {SegmentCoord(0, 0), std::vector<RouteSegment::SpeedCamera>{{0.25, 100}}}
   };
-  TestSpeedCameraSectionBuilding(osmContent, answer);
+  TestSpeedCameraSectionBuilding(osmContent, answer, epsilon);
 }
 
 UNIT_TEST(RoadCategoryToSpeedTest)

--- a/generator/geometry_holder.hpp
+++ b/generator/geometry_holder.hpp
@@ -188,9 +188,10 @@ private:
 
     // points conversion
     tesselator::PointsInfo points;
-    m2::PointU (*D2U)(m2::PointD const &, uint8_t) = &PointDToPointU;
+    m2::PointU (*D2U)(m2::PointD const &, uint8_t, m2::RectD const &) = &PointDToPointU;
     info.GetPointsInfo(saver.GetBasePoint(), saver.GetMaxPoint(),
-                       std::bind(D2U, std::placeholders::_1, cp.GetCoordBits()), points);
+                       std::bind(D2U, std::placeholders::_1, cp.GetCoordBits(), cp.GetLimitRect()),
+                       points);
 
     // triangles processing (should be optimal)
     info.ProcessPortions(points, saver, true);

--- a/generator/postcode_points_builder.cpp
+++ b/generator/postcode_points_builder.cpp
@@ -207,7 +207,7 @@ bool BuildPostcodePointsImpl(FilesContainerR & container, storage::CountryId con
   {
     search::CentersTableBuilder builder;
 
-    builder.SetGeometryParams(feature::DataHeader(container).GetBounds());
+    builder.SetGeometryCodingParams(feature::DataHeader(container).GetDefGeometryCodingParams());
     for (size_t i = 0; i < valueMapping.size(); ++i)
       builder.Put(base::asserted_cast<uint32_t>(i), valueMapping[i]);
 

--- a/indexer/centers_table.hpp
+++ b/indexer/centers_table.hpp
@@ -24,7 +24,8 @@ public:
   {
     V0 = 0,
     V1 = 1,
-    Latest = V1
+    V2 = 2,
+    Latest = V2
   };
 
   struct Header
@@ -32,7 +33,7 @@ public:
     template <typename Sink>
     void Serialize(Sink & sink) const
     {
-      CHECK_EQUAL(static_cast<uint8_t>(m_version), static_cast<uint8_t>(Version::V1), ());
+      CHECK_EQUAL(static_cast<uint8_t>(m_version), static_cast<uint8_t>(Version::V2), ());
       WriteToSink(sink, static_cast<uint8_t>(m_version));
       WriteToSink(sink, m_geometryParamsOffset);
       WriteToSink(sink, m_geometryParamsSize);
@@ -67,32 +68,28 @@ public:
 private:
   using Map = MapUint32ToValue<m2::PointU>;
 
-  bool Init(Reader & reader, serial::GeometryCodingParams const & codingParams,
-            m2::RectD const & limitRect);
+  bool Init(Reader & reader, serial::GeometryCodingParams const & codingParams);
 
   serial::GeometryCodingParams m_codingParams;
   std::unique_ptr<Map> m_map;
   std::unique_ptr<Reader> m_centersSubreader;
-  m2::RectD m_limitRect;
   Version m_version = Version::Latest;
 };
 
 class CentersTableBuilder
 {
 public:
-  void SetGeometryParams(m2::RectD const & limitRect, double pointAccuracy = kMwmPointAccuracy);
+  void SetGeometryCodingParams(serial::GeometryCodingParams const & codingParams);
   void Put(uint32_t featureId, m2::PointD const & center);
   void WriteBlock(Writer & w, std::vector<m2::PointU>::const_iterator begin,
                   std::vector<m2::PointU>::const_iterator end) const;
   void Freeze(Writer & writer) const;
 
-  void SetGeometryCodingParamsV0ForTests(serial::GeometryCodingParams const & codingParams);
   void PutV0ForTests(uint32_t featureId, m2::PointD const & center);
   void FreezeV0ForTests(Writer & writer) const;
 
 private:
   serial::GeometryCodingParams m_codingParams;
-  m2::RectD m_limitRect;
   MapUint32ToValueBuilder<m2::PointU> m_builder;
 };
 }  // namespace search

--- a/indexer/data_header.cpp
+++ b/indexer/data_header.cpp
@@ -57,7 +57,7 @@ namespace feature
   {
     return serial::GeometryCodingParams(
         m_codingParams.GetCoordBits() - (m_scales.back() - m_scales[scaleIndex]) / 2,
-        m_codingParams.GetBasePointUint64());
+        m_codingParams.GetBasePointUint64(), m_codingParams.GetLimitRect());
   }
 
   m2::RectD const DataHeader::GetBounds() const

--- a/indexer/data_header.cpp
+++ b/indexer/data_header.cpp
@@ -117,7 +117,7 @@ namespace feature
   void DataHeader::Load(ModelReaderPtr const & r, version::Format format)
   {
     ReaderSource<ModelReaderPtr> src(r);
-    m_codingParams.Load(src);
+    m_codingParams.Load(src, format >= version::Format::v12);
 
     m_bounds.first = ReadVarInt<int64_t>(src);
     m_bounds.second = ReadVarInt<int64_t>(src);

--- a/indexer/indexer_tests/centers_table_test.cpp
+++ b/indexer/indexer_tests/centers_table_test.cpp
@@ -46,7 +46,7 @@ UNIT_CLASS_TEST(CentersTableTest, Smoke)
     CentersTableBuilder builder;
     feature::DataHeader header(kMap);
 
-    builder.SetGeometryParams(header.GetBounds());
+    builder.SetGeometryCodingParams(header.GetDefGeometryCodingParams());
     fv.GetVector().ForEach(
         [&](FeatureType & ft, uint32_t id) { builder.Put(id, feature::GetCenter(ft)); });
 
@@ -84,7 +84,7 @@ UNIT_CLASS_TEST(CentersTableTest, SmokeV0)
   {
     CentersTableBuilder builder;
 
-    builder.SetGeometryCodingParamsV0ForTests(codingParams);
+    builder.SetGeometryCodingParams(codingParams);
     fv.GetVector().ForEach(
         [&](FeatureType & ft, uint32_t id) { builder.PutV0ForTests(id, feature::GetCenter(ft)); });
 
@@ -117,7 +117,9 @@ UNIT_CLASS_TEST(CentersTableTest, Subset)
   {
     CentersTableBuilder builder;
 
-    builder.SetGeometryParams({{0.0, 0.0}, {2.0, 2.0}});
+    m2::RectD rect({0.0, 0.0}, {2.0, 2.0});
+    serial::GeometryCodingParams params(GetCoordBits(rect, kMwmPointAccuracy), rect.Center(), rect);
+    builder.SetGeometryCodingParams(params);
     for (auto const & feature : features)
       builder.Put(feature.first, feature.second);
 

--- a/platform/mwm_version.hpp
+++ b/platform/mwm_version.hpp
@@ -28,7 +28,8 @@ enum class Format
            // header, sdx section with header, dat section renamed to features, features section with
            // header).
   v11,     // September 2020 (compressed string storage for metadata).
-  lastFormat = v11
+  v12,     // December 2020 (coding params with limit rect).
+  lastFormat = v12
 };
 
 enum class MwmType

--- a/routing/cross_mwm_connector_serialization.hpp
+++ b/routing/cross_mwm_connector_serialization.hpp
@@ -400,7 +400,7 @@ private:
       m_sizeTransitions = ReadPrimitiveFromSource<decltype(m_sizeTransitions)>(src);
       m_granularity = ReadPrimitiveFromSource<decltype(m_granularity)>(src);
       if (m_version == kVersion0)
-        serial::GeometryCodingParams().Load(src);
+        serial::GeometryCodingParams().Load(src, false /* haveLimitRect */);
       m_bitsPerCrossMwmId = ReadPrimitiveFromSource<decltype(m_bitsPerCrossMwmId)>(src);
       m_bitsPerMask = ReadPrimitiveFromSource<decltype(m_bitsPerMask)>(src);
 

--- a/topography_generator/utils/contours_serdes.hpp
+++ b/topography_generator/utils/contours_serdes.hpp
@@ -94,7 +94,7 @@ private:
                           topography_generator::Contour & contour)
   {
     serial::GeometryCodingParams codingParams;
-    codingParams.Load(source);
+    codingParams.Load(source, true /* haveLimitRect */);
     std::vector<m2::PointD> points;
     serial::LoadOuterPath(source, codingParams, points);
     contour = std::move(points);


### PR DESCRIPTION
Сжатие основано на той же идее что реализована в CentersTable -- делаем кодирование PointUToPointD не на основе всего пространства координат, а на основе пространства в котором лежит mwm.

Включает в себя фикс https://github.com/mapsme/omim/pull/14057

DNM без поддержки питона -- нужно добавить поддержку разных форматов в tools/python/mwm

