### PR TITLE
[map] Removed unused lampda parameter.

### DIFF
--- a/map/search_mark.cpp
+++ b/map/search_mark.cpp
@@ -828,7 +828,7 @@ void SearchMarks::OnActivate(FeatureID const & featureId)
 {
   m_selectedFeature = featureId;
   m_visitedSearchMarks.erase(featureId);
-  ProcessMarks([this, &featureId](SearchMarkPoint * mark) -> base::ControlFlow
+  ProcessMarks([&featureId](SearchMarkPoint * mark) -> base::ControlFlow
   {
     if (featureId != mark->GetFeatureID())
       return base::ControlFlow::Continue;


### PR DESCRIPTION
Fixed compiler warning: 

```
warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
  ProcessMarks([this, &featureId](SearchMarkPoint * mark) -> base::ControlFlow
```