### PR TITLE
[android] fix for lost jni signature refactoring

### DIFF
--- a/android/jni/com/mapswithme/platform/Platform.cpp
+++ b/android/jni/com/mapswithme/platform/Platform.cpp
@@ -124,9 +124,10 @@ Platform::ChargingStatus Platform::GetChargingStatus()
   ASSERT(clazzBatteryState, ());
 
   static jmethodID const getChargingMethodId =
-      jni::GetStaticMethodID(env, clazzBatteryState, "getChargingStatus", "()I");
+      jni::GetStaticMethodID(env, clazzBatteryState, "getChargingStatus", "(Landroid/content/Context;)I");
+  jobject context = android::Platform::Instance().GetContext();
   return static_cast<Platform::ChargingStatus>(
-      env->CallStaticIntMethod(clazzBatteryState, getChargingMethodId));
+      env->CallStaticIntMethod(clazzBatteryState, getChargingMethodId, context));
 }
 
 uint8_t Platform::GetBatteryLevel()
@@ -140,9 +141,9 @@ uint8_t Platform::GetBatteryLevel()
   ASSERT(clazzBatteryState, ());
 
   static auto const getLevelMethodId =
-      jni::GetStaticMethodID(env, clazzBatteryState, "getLevel", "()I");
-
-  return static_cast<uint8_t>(env->CallStaticIntMethod(clazzBatteryState, getLevelMethodId));
+      jni::GetStaticMethodID(env, clazzBatteryState, "getLevel", "(Landroid/content/Context;)I");
+  jobject context = android::Platform::Instance().GetContext();
+  return static_cast<uint8_t>(env->CallStaticIntMethod(clazzBatteryState, getLevelMethodId, context));
 }
 
 void Platform::SetGuiThread(std::unique_ptr<base::TaskLoop> guiThread)

--- a/android/src/com/mapswithme/util/BatteryState.java
+++ b/android/src/com/mapswithme/util/BatteryState.java
@@ -37,6 +37,8 @@ public final class BatteryState
     return new State(getLevel(batteryStatus), getChargingStatus(batteryStatus));
   }
 
+  // Called from JNI.
+  @SuppressWarnings("unused")
   @IntRange(from=0, to=100)
   public static int getLevel()
   {
@@ -53,6 +55,14 @@ public final class BatteryState
   private static int getLevel(@NonNull Intent batteryStatus)
   {
     return batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, 0);
+  }
+
+  // Called from JNI.
+  @SuppressWarnings("unused")
+  @ChargingStatus
+  public static int getChargingStatus(@NonNull Context context)
+  {
+    return getState(context).getChargingStatus();
   }
 
   @ChargingStatus


### PR DESCRIPTION
Crash:
Crashed: Thread :  SIGABRT  0x00002872000005d7
#00 pc 0x7917cd3134 libc.so 
#01 pc 0x7917cd3104 libc.so 
#02 pc 0x78942c5a54 libart.so 
#03 pc 0x79166b15b4 libbase.so 
#04 pc 0x789430a658 libart.so 
#05 pc 0x7893f78304 libart.so 
#06 pc 0x7893f654c0 libart.so 
#07 pc 0x7894331a50 libart.so 
#08 pc 0x78943355ac libart.so 
#09 pc 0x789421cee0 libart.so 
#10 pc 0x789421de68 libart.so 
#11 pc 0x78942e7af0 libart.so 
#12 pc 0x78943093b4 libart.so 
#13 pc 0x78943052b8 libart.so 
#14 pc 0x789431f38c libart.so 
#15 pc 0x7894318794 libart.so 
#16 pc 0x7894317b6c libart.so 
#17 pc 0x78942c56bc libart.so 
#18 pc 0x79166b15b4 libbase.so 
#19 pc 0x78941868c4 libart.so 
#20 pc 0x78941c467c libart.so 
#21 pc 0x78256f3124 libmapswithme.so (_JNIEnv::CallStaticIntMethod(_jclass*, _jmethodID*, ...) [jni.h:770])
#22 pc 0x78256f3194 libmapswithme.so (Platform::GetBatteryLevel() [Platform.cpp:148])
#23 pc 0x7825deff64 libmapswithme.so (platform::BatteryLevelTracker::RequestBatteryLevel() [battery_tracker.cpp:52])
#24 pc 0x7825defee8 libmapswithme.so (platform::BatteryLevelTracker::Subscribe(platform::BatteryLevelTracker::Subscriber*) [battery_tracker.cpp:27])
#25 pc 0x7825854988 libmapswithme.so (power_management::PowerManager::Load() [power_manager.cpp:55])
#26 pc 0x78257b7014 libmapswithme.so (Framework::Framework(FrameworkParams const&) [framework.cpp:558])
#27 pc 0x78256b8ed0 libmapswithme.so (android::Framework::Framework() [Framework.cpp:119])
#28 pc 0x78256d35f4 libmapswithme.so (std::__ndk1::__unique_if<android::Framework>::__unique_single std::__ndk1::make_unique<android::Framework>() [memory:3003])
#29 pc 0x7827704670 base.odex 
#30 pc 0x78283a5d1f  