### PR TITLE
[android] Fixed night mode in some edittext fields.

### DIFF
--- a/android/res/layout/dialog_edit_text.xml
+++ b/android/res/layout/dialog_edit_text.xml
@@ -5,28 +5,25 @@
   android:minWidth="@dimen/width_dialog_base"
   android:orientation="vertical"
   android:padding="@dimen/margin_base_plus">
-
   <TextView
     android:id="@+id/tv__title"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/margin_base"
-    android:textAppearance="@style/MwmTextAppearance.Title"/>
-
+    android:textAppearance="@style/MwmTextAppearance.Title" />
   <com.google.android.material.textfield.TextInputLayout
     android:id="@+id/input"
+    style="?fontBody1"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
-
+    android:layout_height="wrap_content"
+    android:textColorHint="?android:textColorSecondary">
     <EditText
       android:id="@+id/et__input"
       style="@style/MwmWidget.PlacePage.EditText"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:maxLength="100"
       android:inputType="text|textCapSentences"
-      android:singleLine="true"/>
-
+      android:maxLength="100"
+      android:singleLine="true" />
   </com.google.android.material.textfield.TextInputLayout>
-
 </LinearLayout>

--- a/android/res/layout/edit_bookmark_common.xml
+++ b/android/res/layout/edit_bookmark_common.xml
@@ -15,8 +15,10 @@
     android:layout_marginRight="@dimen/margin_half"
     android:orientation="vertical">
     <com.mapswithme.maps.widget.CustomTextInputLayout
+      style="?fontBody1"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
+      android:layout_height="wrap_content"
+      android:textColorHint="?android:textColorSecondary">
       <EditText
         android:id="@+id/et__bookmark_name"
         style="@style/MwmWidget.PlacePage.EditText"
@@ -24,10 +26,9 @@
         android:layout_height="wrap_content"
         android:hint="@string/name"
         android:inputType="textCapSentences"
-        android:singleLine="true"/>
+        android:singleLine="true" />
     </com.mapswithme.maps.widget.CustomTextInputLayout>
   </LinearLayout>
-
   <RelativeLayout
     android:id="@+id/rl__bookmark_set"
     android:layout_width="match_parent"
@@ -39,11 +40,10 @@
       android:id="@+id/tv__bookmark_set_title"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginRight="@dimen/margin_quadruple"
       android:layout_marginTop="@dimen/margin_base"
+      android:layout_marginRight="@dimen/margin_quadruple"
       android:text="@string/set"
-      android:textAppearance="@style/MwmTextAppearance.Body3"/>
-
+      android:textAppearance="@style/MwmTextAppearance.Body3" />
     <TextView
       android:id="@+id/tv__bookmark_set"
       android:layout_width="match_parent"
@@ -54,47 +54,40 @@
       android:background="?attr/selectableItemBackground"
       android:clickable="true"
       android:drawableRight="@drawable/ic_arrow_down"
-      android:paddingBottom="@dimen/margin_half"
       android:paddingTop="@dimen/margin_quarter_plus"
-      android:textAppearance="@style/MwmTextAppearance.Body1"/>
-
+      android:paddingBottom="@dimen/margin_half"
+      android:textAppearance="@style/MwmTextAppearance.Body1" />
     <View
       android:layout_width="match_parent"
       android:layout_height="1dp"
       android:layout_alignParentBottom="true"
-      android:layout_marginBottom="@dimen/margin_half"
       android:layout_marginRight="@dimen/margin_quadruple"
-      android:background="@color/divider"/>
-
+      android:layout_marginBottom="@dimen/margin_half"
+      android:background="@color/divider" />
     <ImageView
       android:id="@+id/iv__bookmark_color"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
       android:layout_alignParentRight="true"
+      android:layout_alignParentBottom="true"
       android:background="?clickableBackground"
       android:padding="@dimen/margin_half"
-      tools:src="@drawable/ic_bookmark_none"/>
+      tools:src="@drawable/ic_bookmark_none" />
   </RelativeLayout>
-
-  <LinearLayout
+  <com.mapswithme.maps.widget.CustomTextInputLayout
+    style="?fontBody1"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_below="@id/rl__bookmark_set"
     android:layout_margin="@dimen/margin_half"
-    android:orientation="vertical"
-    android:paddingTop="@dimen/margin_base">
-
-    <com.mapswithme.maps.widget.CustomTextInputLayout
+    android:paddingTop="@dimen/margin_half"
+    android:textColorHint="?android:textColorSecondary">
+    <EditText
+      android:id="@+id/et__description"
+      style="@style/MwmWidget.PlacePage.EditText"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
-      <EditText
-        android:id="@+id/et__description"
-        style="@style/MwmWidget.PlacePage.EditText"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/edit_description_hint"
-        android:inputType="textMultiLine"/>
-    </com.mapswithme.maps.widget.CustomTextInputLayout>
-  </LinearLayout>
+      android:layout_height="wrap_content"
+      android:hint="@string/edit_description_hint"
+      android:inputType="textMultiLine" />
+  </com.mapswithme.maps.widget.CustomTextInputLayout>
 </RelativeLayout>

--- a/android/res/layout/fragment_edit_description.xml
+++ b/android/res/layout/fragment_edit_description.xml
@@ -19,9 +19,8 @@
       android:gravity="center_vertical"
       android:padding="@dimen/margin_half"
       android:text="@string/save"
-      android:textAppearance="@style/MwmTextAppearance.Toolbar.Title.Button"/>
+      android:textAppearance="@style/MwmTextAppearance.Toolbar.Title.Button" />
   </androidx.appcompat.widget.Toolbar>
-
   <FrameLayout
     style="@style/MwmWidget.FrameLayout.Elevation"
     android:layout_width="match_parent"
@@ -36,6 +35,7 @@
       android:layout_height="wrap_content"
       android:hint="@string/edit_description_hint"
       android:includeFontPadding="false"
-      android:inputType="textMultiLine"/>
+      android:inputType="textMultiLine"
+      android:textColorHint="?android:textColorSecondary" />
   </FrameLayout>
 </RelativeLayout>

--- a/android/res/layout/fragment_editor.xml
+++ b/android/res/layout/fragment_editor.xml
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   tools:context=".editor.EditorActivity"
   tools:ignore="DuplicateIds">
-
   <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/margin_half"
     android:orientation="vertical">
-
     <androidx.cardview.widget.CardView
       android:id="@+id/cv__category"
       style="@style/MwmWidget.Editor.CardView">
-
       <RelativeLayout
         android:id="@+id/category"
         style="@style/MwmWidget.Editor.MetadataBlock.Clickable"
@@ -24,25 +22,20 @@
         android:layout_height="@dimen/editor_height_field"
         android:layout_marginBottom="0dp"
         android:padding="@dimen/margin_half_plus">
-
         <ImageView
           android:id="@+id/icon"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:layout_centerVertical="true"
           android:layout_marginEnd="@dimen/margin_half_plus"
-          android:layout_marginLeft="@dimen/margin_quarter"
-          android:layout_marginRight="@dimen/margin_half_plus"
           android:layout_marginStart="@dimen/margin_quarter"
           android:tint="?iconTint"
           tools:src="@drawable/ic_operator"/>
-
         <Space
           android:id="@+id/anchor_center"
           android:layout_width="0dp"
           android:layout_height="0dp"
           android:layout_centerVertical="true"/>
-
         <TextView
           android:id="@+id/title"
           android:layout_width="match_parent"
@@ -55,42 +48,30 @@
           android:text="@string/editor_edit_place_category_title"
           android:textAppearance="@style/MwmTextAppearance.Body4"
           tools:text="Trololo"/>
-
         <TextView
           android:id="@+id/name"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_alignLeft="@id/title"
           android:layout_alignStart="@id/title"
           android:layout_below="@id/anchor_center"
           android:textAppearance="@style/MwmTextAppearance.Body1"
           tools:text="Ololo"/>
-
       </RelativeLayout>
-
     </androidx.cardview.widget.CardView>
-
     <androidx.cardview.widget.CardView
       android:id="@+id/cv__name"
       style="@style/MwmWidget.Editor.CardView">
-
       <include layout="@layout/localized_name"/>
-
     </androidx.cardview.widget.CardView>
-
     <androidx.cardview.widget.CardView
       android:id="@+id/cv__address"
       style="@style/MwmWidget.Editor.CardView">
-
       <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:paddingEnd="@dimen/margin_base"
-        android:paddingLeft="@dimen/margin_base"
-        android:paddingRight="@dimen/margin_base"
         android:paddingStart="@dimen/margin_base">
-
         <TextView
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
@@ -99,77 +80,59 @@
           android:text="@string/address"
           android:textAppearance="@style/MwmTextAppearance.Body3"
           tools:ignore="UnusedAttribute"/>
-
         <RelativeLayout
           android:id="@+id/block_street"
           style="@style/MwmWidget.Editor.MetadataBlock.Clickable"
           android:paddingBottom="@dimen/margin_half"
           android:paddingTop="@dimen/margin_half">
-
           <ImageView
             style="@style/MwmWidget.Editor.MetadataIcon"
-            android:src="@drawable/ic_address"/>
-
+            android:src="@drawable/ic_address"
+            tools:ignore="ContentDescription" />
           <TextView
             android:id="@+id/street_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/editor_margin_left"
             android:layout_marginStart="@dimen/editor_margin_left"
             android:text="@string/street"
             android:textAppearance="@style/MwmTextAppearance.Body4"/>
-
           <TextView
             android:id="@+id/street"
             style="@style/MwmWidget.Editor.FieldLayout"
             android:layout_below="@id/street_title"
             android:layout_marginTop="@dimen/margin_quarter"
-            android:drawableEnd="@drawable/ic_arrow_down"
-            android:drawableRight="@drawable/ic_arrow_down"
             android:gravity="center_vertical"
             android:textAppearance="@style/MwmTextAppearance.Body1"
-            tools:text="Red str."/>
-
+            tools:text="Red str."
+            app:drawableEndCompat="@drawable/ic_arrow_down" />
           <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_alignLeft="@id/street"
             android:layout_alignStart="@id/street"
             android:layout_below="@id/street"
             android:layout_marginTop="@dimen/margin_quarter_plus"
             android:background="?dividerHorizontal"/>
-
         </RelativeLayout>
-
         <include
           android:id="@+id/block_building"
           layout="@layout/item_editor_input"/>
-
         <include
           android:id="@+id/block_zipcode"
           layout="@layout/item_editor_input"/>
-
         <include
           android:id="@+id/block_levels"
           layout="@layout/item_editor_input"/>
-
       </LinearLayout>
-
     </androidx.cardview.widget.CardView>
-
     <androidx.cardview.widget.CardView
       android:id="@+id/cv__details"
       style="@style/MwmWidget.Editor.CardView">
-
       <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:paddingEnd="@dimen/margin_base"
-        android:paddingLeft="@dimen/margin_base"
-        android:paddingRight="@dimen/margin_base"
         android:paddingStart="@dimen/margin_base">
-
         <TextView
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
@@ -178,137 +141,110 @@
           android:text="@string/details"
           android:textAppearance="@style/MwmTextAppearance.Body3"
           tools:ignore="UnusedAttribute"/>
-
         <include
           android:id="@+id/block_opening_hours"
           layout="@layout/item_opening_hours"/>
-
         <include
           android:id="@+id/block_phone"
           layout="@layout/item_editor_input"/>
-
         <include
           android:id="@+id/block_website"
           layout="@layout/item_editor_input"/>
-
         <include
           android:id="@+id/block_email"
           layout="@layout/item_editor_input"/>
-
         <include
           android:id="@+id/block_operator"
           layout="@layout/item_editor_input"/>
-
         <RelativeLayout
           android:id="@+id/block_cuisine"
           style="@style/MwmWidget.Editor.MetadataBlock.Clickable"
           android:paddingBottom="@dimen/margin_half"
           android:paddingTop="@dimen/margin_half">
-
           <ImageView
             style="@style/MwmWidget.Editor.MetadataIcon"
-            android:src="@drawable/ic_cuisine"/>
-
+            android:src="@drawable/ic_cuisine"
+            tools:ignore="ContentDescription" />
           <TextView
             android:id="@+id/title_cuisine"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/editor_margin_left"
             android:layout_marginStart="@dimen/editor_margin_left"
             android:text="@string/cuisine"
             android:textAppearance="@style/MwmTextAppearance.Body4"/>
-
           <TextView
             android:id="@+id/cuisine"
             style="@style/MwmWidget.Editor.FieldLayout"
             android:layout_below="@id/title_cuisine"
             android:layout_marginTop="@dimen/margin_quarter"
-            android:drawableEnd="@drawable/ic_arrow_down"
-            android:drawableRight="@drawable/ic_arrow_down"
             android:gravity="center_vertical"
             android:textAppearance="@style/MwmTextAppearance.Body1"
-            tools:text="Italian, russian, russian, russian, russian, russian, russian, russian, russian"/>
-
+            tools:text="Italian, russian, russian, russian, russian, russian, russian, russian, russian"
+            app:drawableEndCompat="@drawable/ic_arrow_down" />
           <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:layout_alignLeft="@id/cuisine"
             android:layout_alignStart="@id/cuisine"
             android:layout_below="@id/cuisine"
             android:layout_marginTop="@dimen/margin_quarter_plus"
             android:background="?dividerHorizontal"/>
-
         </RelativeLayout>
-
         <RelativeLayout
           android:id="@+id/block_wifi"
           style="@style/MwmWidget.Editor.MetadataBlock.Clickable">
-
           <ImageView
             style="@style/MwmWidget.Editor.MetadataIcon"
-            android:src="@drawable/ic_wifi"/>
-
+            android:src="@drawable/ic_wifi"
+            tools:ignore="ContentDescription" />
           <TextView
             style="@style/MwmWidget.Editor.FieldLayout.EditText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
-            android:layout_marginLeft="@dimen/editor_margin_left"
             android:layout_marginStart="@dimen/editor_margin_left"
             android:layout_toLeftOf="@+id/sw__wifi"
             android:layout_toStartOf="@+id/sw__wifi"
             android:text="@string/wifi"/>
-
           <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/sw__wifi"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
             android:layout_centerVertical="true"/>
         </RelativeLayout>
-
       </LinearLayout>
-
     </androidx.cardview.widget.CardView>
-
     <androidx.cardview.widget.CardView
       android:id="@+id/cv__more"
       style="@style/MwmWidget.Editor.CardView">
-
       <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:padding="@dimen/margin_base">
-
         <TextView
           android:layout_width="match_parent"
           android:layout_height="32dp"
           android:text="@string/editor_other_info"
           android:textAppearance="@style/MwmTextAppearance.Body2"/>
-
         <com.mapswithme.maps.widget.CustomTextInputLayout
           android:id="@+id/custom_input"
           style="@style/MwmWidget.Editor.CustomTextInput"
           android:gravity="center_vertical"
-          android:minHeight="74dp">
-
+          android:minHeight="74dp"
+          android:textColorHint="?android:textColorSecondary">
           <EditText
             android:id="@+id/input"
             style="@style/MwmWidget.Editor.FieldLayout.EditText"
             android:inputType="textMultiLine"
             android:hint="@string/editor_detailed_description_hint"/>
-
         </com.mapswithme.maps.widget.CustomTextInputLayout>
-
         <TextView
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:layout_marginTop="@dimen/margin_half"
           android:text="@string/editor_detailed_description"
           android:textAppearance="@style/MwmTextAppearance.Body4"/>
-
         <TextView
           android:id="@+id/about_osm"
           android:layout_width="match_parent"
@@ -320,17 +256,13 @@
           android:textAppearance="@style/MwmTextAppearance.Body4"
           android:textColor="?colorAccent"
           android:textSize="@dimen/text_size_body_4"/>
-
       </LinearLayout>
-
     </androidx.cardview.widget.CardView>
-
     <androidx.cardview.widget.CardView
       android:id="@+id/cv__more"
       style="@style/MwmWidget.Editor.CardView"
       android:layout_marginTop="@dimen/margin_double"
       android:layout_marginBottom="@dimen/margin_base">
-
       <TextView
         android:id="@+id/reset"
         android:layout_width="match_parent"
@@ -341,7 +273,5 @@
         android:textColor="@color/base_red"
         tools:text="Reset my changes"/>
     </androidx.cardview.widget.CardView>
-
   </LinearLayout>
-
 </androidx.core.widget.NestedScrollView>

--- a/android/res/layout/fragment_osm_login.xml
+++ b/android/res/layout/fragment_osm_login.xml
@@ -5,7 +5,6 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">
-
   <androidx.appcompat.widget.Toolbar
     android:id="@+id/toolbar"
     style="@style/MwmWidget.ToolbarStyle"
@@ -14,74 +13,61 @@
     android:background="?cardBackground"
     android:gravity="end|center_vertical"
     android:theme="@style/MwmWidget.ToolbarTheme.Light"
-    tools:ignore="UnusedAttribute"/>
-
+    tools:ignore="UnusedAttribute" />
   <ScrollView
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?cardBackground"
     android:fillViewport="true"
     tools:ignore="DuplicateIds">
-
     <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:orientation="vertical"
-      android:padding="@dimen/margin_base"
       android:clipChildren="false"
       android:clipToPadding="false"
+      android:orientation="vertical"
+      android:padding="@dimen/margin_base"
       tools:ignore="ScrollViewSize">
-
       <com.mapswithme.maps.widget.CustomTextInputLayout
         style="@style/MwmWidget.Editor.CustomTextInput"
         android:layout_marginTop="@dimen/margin_base"
-        android:minHeight="@dimen/height_block_base">
-
+        android:minHeight="@dimen/height_block_base"
+        android:textColorHint="?android:textColorSecondary">
         <EditText
           android:id="@+id/osm_username"
           style="@style/MwmWidget.Editor.FieldLayout.EditText"
-          android:hint="@string/email_or_username"
-          android:textAppearance="@style/MwmTextAppearance.Body1"/>
-
+          android:hint="@string/email_or_username" />
       </com.mapswithme.maps.widget.CustomTextInputLayout>
-
       <com.mapswithme.maps.widget.CustomTextInputLayout
         style="@style/MwmWidget.Editor.CustomTextInput"
         android:layout_marginTop="@dimen/margin_base"
-        android:minHeight="@dimen/height_block_base">
-
+        android:minHeight="@dimen/height_block_base"
+        android:textColorHint="?android:textColorSecondary">
         <EditText
           android:id="@+id/osm_password"
           style="@style/MwmWidget.Editor.FieldLayout.EditText"
           android:hint="@string/password"
-          android:inputType="textPassword"
-          android:textAppearance="@style/MwmTextAppearance.Body1"/>
-
+          android:inputType="textPassword" />
       </com.mapswithme.maps.widget.CustomTextInputLayout>
-
       <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_base">
-
         <Button
           android:id="@+id/login"
           style="@style/MwmWidget.Button.Accent"
           android:layout_width="match_parent"
           android:layout_height="@dimen/editor_auth_btn_height"
           android:text="@string/login"
-          android:textAppearance="@style/MwmTextAppearance.Body1.Light"/>
-
+          android:textAppearance="@style/MwmTextAppearance.Body1.Light" />
         <ProgressBar
           android:id="@+id/osm_login_progress"
           android:layout_width="@dimen/editor_auth_btn_height"
           android:layout_height="@dimen/editor_auth_btn_height"
           android:layout_gravity="center"
           android:elevation="@dimen/design_fab_elevation"
-          tools:targetApi="lollipop"/>
-
+          tools:targetApi="lollipop" />
       </FrameLayout>
-
       <TextView
         android:id="@+id/lost_password"
         android:layout_width="wrap_content"
@@ -91,10 +77,7 @@
         android:padding="@dimen/margin_half"
         android:text="@string/forgot_password"
         android:textAllCaps="true"
-        android:textAppearance="@style/MwmTextAppearance.Body3"/>
-
+        android:textAppearance="@style/MwmTextAppearance.Body3" />
     </LinearLayout>
-
   </ScrollView>
-
 </LinearLayout>

--- a/android/res/layout/fragment_ugc_editor.xml
+++ b/android/res/layout/fragment_ugc_editor.xml
@@ -20,46 +20,46 @@
       android:layout_gravity="end|center_vertical"
       android:background="?selectableItemBackgroundBorderless"
       android:scaleType="centerInside"
-      android:src="@drawable/ic_done"/>
+      android:src="@drawable/ic_done"
+      tools:ignore="ContentDescription" />
   </androidx.appcompat.widget.Toolbar>
   <ScrollView
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
     <LinearLayout
-      android:orientation="vertical"
-      android:paddingTop="@dimen/margin_half"
-      android:background="?cardBackground"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
+      android:layout_height="wrap_content"
+      android:background="?cardBackground"
+      android:orientation="vertical"
+      android:paddingTop="@dimen/margin_half">
       <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/ratings"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        tools:listitem="@layout/item_ugc_rating"/>
+        tools:listitem="@layout/item_ugc_rating" />
       <View
         android:layout_width="match_parent"
         android:layout_height="@dimen/divider_height"
-        android:background="?dividerHorizontal"/>
+        android:background="?dividerHorizontal" />
       <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/input_layout"
-        android:layout_marginTop="@dimen/margin_base"
+        style="?fontBody1"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_base"
+        android:textColorHint="?android:textColorSecondary">
         <EditText
           android:id="@+id/review"
           android:layout_width="match_parent"
           android:layout_height="@dimen/rating_user_review_min_height"
-          android:textAppearance="@style/MwmTextAppearance.Body1"
           android:gravity="top"
+          android:hint="@string/placepage_reviews_hint"
+          android:inputType="textMultiLine|textCapSentences"
           android:maxLength="600"
-          android:paddingLeft="@dimen/margin_base"
           android:paddingStart="@dimen/margin_base"
-          android:paddingRight="@dimen/margin_base"
           android:paddingEnd="@dimen/margin_base"
           android:paddingBottom="@dimen/margin_base"
-          android:textColorHint="?android:textColorSecondary"
-          android:inputType="textMultiLine|textCapSentences"
-          android:hint="@string/placepage_reviews_hint"/>
+          android:textAppearance="?fontBody1" />
       </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
   </ScrollView>

--- a/android/res/layout/fragment_ugc_route_edit.xml
+++ b/android/res/layout/fragment_ugc_route_edit.xml
@@ -1,114 +1,112 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
-  android:orientation="vertical"
-  android:background="?cardBackground"
   android:layout_width="match_parent"
-  android:layout_height="match_parent">
+  android:layout_height="match_parent"
+  android:background="?cardBackground"
+  android:orientation="vertical">
   <androidx.appcompat.widget.Toolbar
     android:id="@+id/toolbar"
     style="@style/MwmWidget.ToolbarStyle"
     android:layout_width="match_parent"
     android:layout_height="?attr/actionBarSize"
-    android:theme="@style/MwmWidget.ToolbarTheme"/>
+    android:theme="@style/MwmWidget.ToolbarTheme" />
   <androidx.core.widget.NestedScrollView
-    android:scrollbars="none"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:fillViewport="true"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-  <LinearLayout
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:scrollbars="none">
     <LinearLayout
-      android:orientation="vertical"
-      android:paddingStart="@dimen/margin_base"
-      android:paddingEnd="@dimen/margin_base"
-      android:paddingRight="@dimen/margin_base"
-      android:paddingLeft="@dimen/margin_base"
-      android:paddingBottom="@dimen/bookmark_hide_btn_padding_top"
-      android:paddingTop="@dimen/margin_half_plus"
       android:layout_width="match_parent"
-      android:layout_height="wrap_content">
-      <TextView
-        android:text="@string/ugc_route_edit_list_name"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+      android:layout_height="match_parent"
+      android:orientation="vertical">
       <LinearLayout
-        android:orientation="horizontal"
-        android:id="@+id/edit_name_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-        <EditText
-          android:id="@+id/edit_category_name_view"
-          android:layout_weight="1"
-          android:layout_width="0dp"
-          android:background="@null"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="@dimen/margin_base"
+        android:paddingLeft="@dimen/margin_base"
+        android:paddingTop="@dimen/margin_half_plus"
+        android:paddingEnd="@dimen/margin_base"
+        android:paddingRight="@dimen/margin_base"
+        android:paddingBottom="@dimen/bookmark_hide_btn_padding_top">
+        <TextView
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginRight="@dimen/margin_base"
-          android:layout_marginEnd="@dimen/margin_base"/>
-        <ImageView
-          android:id="@+id/edit_text_clear_btn"
-          android:src="?attr/icClearRounded"
-          android:background="?selectableItemBackgroundBorderless"
-          android:layout_gravity="center"
-          android:layout_weight="0"
-          android:layout_width="@dimen/margin_base_plus"
-          android:layout_height="@dimen/margin_base_plus"/>
+          android:text="@string/ugc_route_edit_list_name"
+          android:textAppearance="?android:attr/textAppearanceSmall" />
+        <LinearLayout
+          android:id="@+id/edit_name_container"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal">
+          <EditText
+            android:id="@+id/edit_category_name_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/margin_base"
+            android:layout_marginRight="@dimen/margin_base"
+            android:layout_weight="1"
+            android:background="@null" />
+          <ImageView
+            android:id="@+id/edit_text_clear_btn"
+            android:layout_width="@dimen/margin_base_plus"
+            android:layout_height="@dimen/margin_base_plus"
+            android:layout_gravity="center"
+            android:layout_weight="0"
+            android:background="?selectableItemBackgroundBorderless"
+            android:src="?attr/icClearRounded" />
+        </LinearLayout>
+        <View
+          android:layout_width="match_parent"
+          android:layout_height="@dimen/divider_height"
+          android:layout_marginTop="@dimen/margin_half"
+          android:background="?attr/iconTintDisabled" />
       </LinearLayout>
+      <include layout="@layout/list_divider" />
+      <LinearLayout
+        android:id="@+id/open_sharing_options_screen_btn_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:orientation="vertical"
+        android:paddingStart="@dimen/margin_base"
+        android:paddingLeft="@dimen/margin_base"
+        android:paddingTop="@dimen/margin_base"
+        android:paddingEnd="@dimen/margin_base"
+        android:paddingRight="@dimen/margin_base"
+        android:paddingBottom="@dimen/margin_half_plus">
+        <TextView
+          android:id="@+id/sharing_options_title"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="@string/sharing_options"
+          android:textAppearance="?android:attr/textAppearanceMedium"
+          android:textColor="?android:attr/textColorPrimary" />
+        <TextView
+          android:id="@+id/sharing_options_desc"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="@string/sharing_options"
+          android:textAppearance="?android:attr/textAppearance" />
+      </LinearLayout>
+      <include layout="@layout/list_divider" />
+      <EditText
+        android:id="@+id/edit_description"
+        style="?fontBody1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@null"
+        android:hint="@string/ugc_route_edit_description_hint"
+        android:minHeight="@dimen/height_item_multiline"
+        android:paddingStart="@dimen/margin_base"
+        android:paddingEnd="@dimen/margin_base"
+        android:textColorHint="?android:textColorSecondary" />
       <View
-        android:background="?attr/iconTintDisabled"
-        android:layout_marginTop="@dimen/margin_half"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/divider_height"/>
+        android:layout_height="match_parent"
+        android:background="?android:attr/windowBackground" />
     </LinearLayout>
-    <include layout="@layout/list_divider"/>
-    <LinearLayout
-      android:id="@+id/open_sharing_options_screen_btn_container"
-      android:orientation="vertical"
-      android:paddingStart="@dimen/margin_base"
-      android:paddingEnd="@dimen/margin_base"
-      android:paddingRight="@dimen/margin_base"
-      android:paddingLeft="@dimen/margin_base"
-      android:paddingTop="@dimen/margin_base"
-      android:paddingBottom="@dimen/margin_half_plus"
-      android:background="?attr/selectableItemBackground"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content">
-      <TextView
-        android:id="@+id/sharing_options_title"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:textColor="?android:attr/textColorPrimary"
-        android:text="@string/sharing_options"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-      <TextView
-        android:id="@+id/sharing_options_desc"
-        android:textAppearance="?android:attr/textAppearance"
-        android:text="@string/sharing_options"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
-    </LinearLayout>
-
-    <include layout="@layout/list_divider"/>
-    <EditText
-      android:id="@+id/edit_description"
-      android:background="@null"
-      android:hint="@string/ugc_route_edit_description_hint"
-      android:minHeight="@dimen/height_item_multiline"
-      android:paddingStart="@dimen/margin_base"
-      android:paddingEnd="@dimen/margin_base"
-      android:paddingRight="@dimen/margin_base"
-      android:paddingLeft="@dimen/margin_base"
-      android:textAppearance="?android:attr/textAppearance"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"/>
-    <View
-      android:background="?android:attr/windowBackground"
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"/>
-  </LinearLayout>
   </androidx.core.widget.NestedScrollView>
 </LinearLayout>
 

--- a/android/res/layout/item_bookmark_create_group.xml
+++ b/android/res/layout/item_bookmark_create_group.xml
@@ -22,13 +22,13 @@
     android:id="@+id/text"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="@dimen/margin_half"
-    android:layout_marginStart="@dimen/margin_half"
     android:layout_gravity="center_vertical"
-    android:textAppearance="@style/MwmTextAppearance.Body3"
-    android:textAllCaps="true"
-    android:text="@string/bookmarks_create_new_group"
-    android:textColor="?colorAccent"
+    android:layout_marginStart="@dimen/margin_half"
+    android:layout_marginLeft="@dimen/margin_half"
     android:fontFamily="@string/robotoMedium"
-    tools:targetApi="jelly_bean"/>
+    android:text="@string/bookmarks_create_new_group"
+    android:textAllCaps="true"
+    android:textAppearance="@style/MwmTextAppearance.Body3"
+    android:textColor="?colorAccent"
+    tools:targetApi="jelly_bean" />
 </LinearLayout>

--- a/android/res/layout/item_editor_input.xml
+++ b/android/res/layout/item_editor_input.xml
@@ -3,25 +3,21 @@
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   style="@style/MwmWidget.Editor.MetadataBlock">
-
   <ImageView
     android:id="@+id/icon"
     style="@style/MwmWidget.Editor.MetadataIcon"
-    tools:src="@drawable/ic_phone"/>
-
+    tools:ignore="ContentDescription"
+    tools:src="@drawable/ic_phone" />
   <com.google.android.material.textfield.TextInputLayout
     android:id="@+id/custom_input"
     style="@style/MwmWidget.Editor.CustomTextInput"
     android:layout_centerVertical="true"
-    android:layout_marginLeft="54dp"
-    android:layout_marginStart="54dp">
-
+    android:layout_marginStart="54dp"
+    android:textColorHint="?android:textColorSecondary">
     <EditText
       android:id="@+id/input"
       style="@style/MwmWidget.Editor.FieldLayout.EditText"
       tools:hint="Hint"
-      tools:text="Input"/>
-
+      tools:text="Input" />
   </com.google.android.material.textfield.TextInputLayout>
-
 </RelativeLayout>

--- a/android/res/layout/item_localized_name.xml
+++ b/android/res/layout/item_localized_name.xml
@@ -7,22 +7,20 @@
   android:animateLayoutChanges="true"
   android:gravity="center_vertical"
   android:orientation="horizontal">
-
   <com.google.android.material.textfield.TextInputLayout
     android:id="@+id/input_layout"
+    style="?fontBody1"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
-    android:layout_weight="1">
-
+    android:layout_weight="1"
+    android:textColorHint="?android:textColorSecondary">
     <EditText
       android:id="@+id/input"
       style="@style/MwmWidget.Editor.FieldLayout.EditText"
       android:hint="@string/editor_edit_place_name_hint"
       android:inputType="textCapSentences"
-      android:singleLine="true"/>
-
+      android:singleLine="true" />
   </com.google.android.material.textfield.TextInputLayout>
-
   <ImageButton
     android:id="@+id/delete"
     android:layout_width="wrap_content"
@@ -30,6 +28,5 @@
     android:background="?selectableItemBackgroundBorderless"
     android:padding="@dimen/margin_half"
     android:src="@drawable/ic_close"
-    android:tint="@color/base_red"/>
-
+    android:tint="@color/base_red" />
 </LinearLayout>


### PR DESCRIPTION
Из таски https://jira.mail.ru/browse/MAPSME-15395 исправлен сценарий:
1) слова в полях для редактирования отображены темным шрифтом на темном фоне, если в приложении темная тема включена, а в настройках девайса выключена 
STR
1. Включить светлую тему в настройках телефона 
2. Открыть приложение 
3. Зайти в настройки 
4. Включить ночной режим 
5. Обратить внимание, на слова в полях для ввода:
5.1. редактирование/добавление места на карту
5.2. создание и настройки списка меток, 
5.3. написание отзыва
5.4. вход в профиль OpenStreetMap
ОР: Слова в полях для ввода написаны светлым шрифтом на темном фоне 
ФР: Слова в полях для ввода написаны темным шрифтом на темном фоне
