### PR TITLE
[generator] Some optimizations part 1

### DIFF
--- a/base/base_tests/string_utils_test.cpp
+++ b/base/base_tests/string_utils_test.cpp
@@ -1121,3 +1121,17 @@ UNIT_TEST(Strings_JoinAny)
                                 [](auto const & item) { return item.second; }), ());
   }
 }
+
+UNIT_TEST(Trim)
+{
+  std::string const kStrWithoutSpaces = "string";
+
+  std::string strWithLeftSpaces = "  " + kStrWithoutSpaces;
+  TEST_EQUAL(strings::TrimLeft(strWithLeftSpaces), kStrWithoutSpaces, ());
+
+  std::string strWithRightSpaces = kStrWithoutSpaces + "  ";
+  TEST_EQUAL(strings::TrimRight(strWithRightSpaces), kStrWithoutSpaces, ());
+
+  std::string strWithLeftRightSpaces = "  " + kStrWithoutSpaces + "  ";
+  TEST_EQUAL(strings::Trim(strWithLeftSpaces), kStrWithoutSpaces, ());
+}

--- a/base/string_utils.cpp
+++ b/base/string_utils.cpp
@@ -203,8 +203,27 @@ char ascii_to_lower(char in)
 }  // namespace
 
 void AsciiToLower(std::string & s) { transform(s.begin(), s.end(), s.begin(), &ascii_to_lower); }
-void Trim(std::string & s) { boost::trim(s); }
-void Trim(std::string & s, char const * anyOf) { boost::trim_if(s, boost::is_any_of(anyOf)); }
+
+std::string & Ltrim(std::string & s)
+{
+  s.erase(s.begin(), std::find_if(s.cbegin(), s.cend(), [](auto c) { return !std::isspace(c); }));
+  return s;
+}
+
+std::string & Rtrim(std::string & s)
+{
+  s.erase(std::find_if(s.crbegin(), s.crend(), [](auto c) { return !std::isspace(c); }).base(),
+          s.end());
+  return s;
+}
+
+std::string & Trim(std::string & s) { return Ltrim(Rtrim(s)); }
+
+std::string & Trim(std::string & s, char const * anyOf)
+{
+  boost::trim_if(s, boost::is_any_of(anyOf));
+  return s;
+}
 
 bool ReplaceFirst(std::string & str, std::string const & from, std::string const & to)
 {

--- a/base/string_utils.cpp
+++ b/base/string_utils.cpp
@@ -204,20 +204,20 @@ char ascii_to_lower(char in)
 
 void AsciiToLower(std::string & s) { transform(s.begin(), s.end(), s.begin(), &ascii_to_lower); }
 
-std::string & Ltrim(std::string & s)
+std::string & TrimLeft(std::string & s)
 {
   s.erase(s.begin(), std::find_if(s.cbegin(), s.cend(), [](auto c) { return !std::isspace(c); }));
   return s;
 }
 
-std::string & Rtrim(std::string & s)
+std::string & TrimRight(std::string & s)
 {
   s.erase(std::find_if(s.crbegin(), s.crend(), [](auto c) { return !std::isspace(c); }).base(),
           s.end());
   return s;
 }
 
-std::string & Trim(std::string & s) { return Ltrim(Rtrim(s)); }
+std::string & Trim(std::string & s) { return TrimLeft(TrimRight(s)); }
 
 std::string & Trim(std::string & s, char const * anyOf)
 {

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -101,8 +101,12 @@ void NormalizeDigits(UniString & us);
 size_t CountNormLowerSymbols(UniString const & s, UniString const & lowStr);
 
 void AsciiToLower(std::string & s);
-// TODO(AlexZ): current impl works as boost trim, that uses default std::locale() to trim.
-// In general, it does not work for any unicode whitespace except ASCII U+0020 one.
+
+// All triming functions return a reference on an input string.
+// They do in-place trimming. In general, it does not work for any unicode whitespace except
+// ASCII U+0020 one.
+std::string & TrimLeft(std::string & s);
+std::string & TrimRight(std::string & s);
 std::string & Trim(std::string & s);
 /// Remove any characters that contain in "anyOf" on left and right side of string s
 std::string & Trim(std::string & s, char const * anyOf);

--- a/base/string_utils.hpp
+++ b/base/string_utils.hpp
@@ -101,11 +101,11 @@ void NormalizeDigits(UniString & us);
 size_t CountNormLowerSymbols(UniString const & s, UniString const & lowStr);
 
 void AsciiToLower(std::string & s);
-// TODO(AlexZ): current boost impl uses default std::locale() to trim.
+// TODO(AlexZ): current impl works as boost trim, that uses default std::locale() to trim.
 // In general, it does not work for any unicode whitespace except ASCII U+0020 one.
-void Trim(std::string & s);
+std::string & Trim(std::string & s);
 /// Remove any characters that contain in "anyOf" on left and right side of string s
-void Trim(std::string & s, char const * anyOf);
+std::string & Trim(std::string & s, char const * anyOf);
 
 // Replace the first match of the search substring in the input with the format string.
 // str - An input string

--- a/generator/osm_element.cpp
+++ b/generator/osm_element.cpp
@@ -9,6 +9,27 @@
 #include <cstring>
 #include <sstream>
 
+namespace
+{
+std::string & Ltrim(std::string & s)
+{
+    s.erase(s.begin(), std::find_if(s.cbegin(), s.cend(), [](auto c) {return !std::isspace(c); }));
+    return s;
+}
+
+std::string & Rtrim(std::string & s)
+{
+    s.erase(std::find_if(s.crbegin(), s.crend(), [](auto c) {return !std::isspace(c); }).base(),
+            s.end());
+    return s;
+}
+
+std::string & Trim(std::string & s)
+{
+    return Ltrim(Rtrim(s));
+}
+}  // namespace
+
 std::string DebugPrint(OsmElement::EntityType type)
 {
   switch (type)
@@ -69,8 +90,7 @@ void OsmElement::AddTag(char const * key, char const * value)
 #undef SKIP_KEY_BY_PREFIX
 
   std::string val{value};
-  strings::Trim(val);
-  m_tags.emplace_back(key, std::move(val));
+  m_tags.emplace_back(key, std::move(Trim(val)));
 }
 
 void OsmElement::AddTag(std::string const & key, std::string const & value)

--- a/generator/osm_element.cpp
+++ b/generator/osm_element.cpp
@@ -9,27 +9,6 @@
 #include <cstring>
 #include <sstream>
 
-namespace
-{
-std::string & Ltrim(std::string & s)
-{
-    s.erase(s.begin(), std::find_if(s.cbegin(), s.cend(), [](auto c) {return !std::isspace(c); }));
-    return s;
-}
-
-std::string & Rtrim(std::string & s)
-{
-    s.erase(std::find_if(s.crbegin(), s.crend(), [](auto c) {return !std::isspace(c); }).base(),
-            s.end());
-    return s;
-}
-
-std::string & Trim(std::string & s)
-{
-    return Ltrim(Rtrim(s));
-}
-}  // namespace
-
 std::string DebugPrint(OsmElement::EntityType type)
 {
   switch (type)
@@ -89,8 +68,8 @@ void OsmElement::AddTag(char const * key, char const * value)
   SKIP_KEY_BY_PREFIX("official_name");
 #undef SKIP_KEY_BY_PREFIX
 
-  std::string val{value};
-  m_tags.emplace_back(key, std::move(Trim(val)));
+  std::string val(value);
+  m_tags.emplace_back(key, std::move(strings::Trim(val)));
 }
 
 void OsmElement::AddTag(std::string const & key, std::string const & value)

--- a/generator/osm_source.cpp
+++ b/generator/osm_source.cpp
@@ -185,7 +185,7 @@ bool ProcessorOsmElementsFromO5M::TryRead(OsmElement & element)
   // iterating in loop. Furthermore, into Tags() method calls Nodes.Skip() and Members.Skip(),
   // thus first call of Nodes (Members) after Tags() will not return any results.
   // So don not reorder the "for" loops (!).
-  auto const entity = *m_pos;
+  auto const & entity = *m_pos;
   element.m_id = entity.id;
   switch (entity.type)
   {


### PR DESCRIPTION
https://github.com/mapsme/omim/pull/11988 по частям


* d19a55fe344d814a4003fa18b6e31f15157c78bf [generator] Added forgotten ref. (generator/osm_source.cpp)
Избавление от копирования, замена на ссылку.

* a9d73c038e419ecd902a727ac5d446579e887a3a [generator] Clear instead of construct and copy. (generator/osm_source.cpp)
Раньше было очищение element с помощью присваивания пустого объекта. Теперь вызов Clear(). Так быстрее, потому что капасити у контейнеров остается прежней, будет меньше реаллокаций.

* b6c65bb7c5a276fa9bd379eb0a1dda9e72158e28 [generator] Used trim without locale instead of boost::trim. (generator/osm_element.cpp)
Добавлена новая реализация Trim. По Таниному комменту про нестандартные пробелы: можно вставить код от сюда https://www.codepile.net/pile/oP4R1V26 в https://wandbox.org/, что бы убедиться, что все ок.

* 976d0e8ebac8594dd001a5f54957e5d666d68b51 [base] Trim impl was replaced to faster. (base/string_utils.cpp, base/string_utils.hpp, generator/osm_element.cpp)
Подмена реализации Trim для base.