### PR TITLE
[transit] Improve get_shape speed.

### DIFF
--- a/transit/world_feed/world_feed.hpp
+++ b/transit/world_feed/world_feed.hpp
@@ -309,7 +309,7 @@ private:
   // Gets frequencies of trips from GTFS.
 
   // Adds shape with mercator points instead of WGS84 lat/lon.
-  bool AddShape(GtfsIdToHash::iterator & iter, std::string const & gtfsShapeId, TransitId lineId);
+  void AddShape(GtfsIdToHash::iterator & iter, gtfs::Shape const & shapeItems, TransitId lineId);
   // Fills stops data, corresponding fields in |m_lines| and builds edges for the road graph.
   bool FillStopsEdges();
 


### PR DESCRIPTION
В некоторых фидах довольно много trip-ов и shape-ов, сейчас с ними работает несколько долго, например
```
cat ~/data/gtfs/omd_0209/trips.txt |wc -l
  441773
cat ~/data/gtfs/omd_0209/shapes.txt |wc -l
  759457
```

Можно вместо того чтобы делать оптимизацию здесь переделать хранение shape-ов в just_gtfs, но я вижу что там всё является отражением того как хранятся данные в файлах и где-то ради этой простоты поступились производительностью. Поэтому там не стала (но если надо перенесу туда).