### PR TITLE
fix build with clang 11: destructor + alias

### DIFF
--- a/coding/files_container.cpp
+++ b/coding/files_container.cpp
@@ -256,7 +256,7 @@ FileReader FilesMappingContainer::GetReader(Tag const & tag) const
 // FilesMappingContainer::Handle
 /////////////////////////////////////////////////////////////////////////////
 
-FilesMappingContainer::Handle::~Handle()
+detail::MappedFile::Handle::~Handle()
 {
   Unmap();
 }


### PR DESCRIPTION
clang 11 generate such error for coding/files_container.cpp:
destructor cannot be declared using a type alias