### PR TITLE
Fix build of skin_generator: no explicit QString->QDir conversation

### DIFF
--- a/skin_generator/generator.cpp
+++ b/skin_generator/generator.cpp
@@ -68,7 +68,7 @@ void SkinGenerator::ProcessSymbols(std::string const & svgDataDir,
     QDir dir(QString(svgDataDir.c_str()));
     QStringList fileNames = dir.entryList(QDir::Files);
 
-    QDir pngDir = dir.absolutePath() + "/png";
+    QDir pngDir(dir.absolutePath() + "/png");
     fileNames += pngDir.entryList(QDir::Files);
 
     // Separate page for symbols.


### PR DESCRIPTION
If code compiles with "-DQT_USE_QSTRINGBUILDER" (for more fast QString
concatenation) then code with implicit QString -> QDir conversation
cause compile time error:
```
conversion from «QStringBuilder<QString, char [5]>» to non-scalar type «QDir» requested
```