### PR TITLE
[transit][generator] Fix cross mwm features numeration for experimental transit.

### DIFF
--- a/generator/transit_generator_experimental.cpp
+++ b/generator/transit_generator_experimental.cpp
@@ -196,11 +196,19 @@ EdgeIdToFeatureId BuildTransit(std::string const & mwmDir, CountryId const & cou
   data.CheckValid();
   data.CheckUnique();
 
+  // Transit graph numerates features according to their orderto their order..
+  EdgeIdToFeatureId edgeToFeature;
+  for (size_t i = 0; i < data.GetEdges().size(); ++i)
+  {
+    auto const & e = data.GetEdges()[i];
+    EdgeId id(e.GetStop1Id(), e.GetStop2Id(), e.GetLineId());
+    edgeToFeature[id] = i;
+  }
+
   FilesContainerW container(mwmPath, FileWriter::OP_WRITE_EXISTING);
   auto writer = container.GetWriter(TRANSIT_FILE_TAG);
   data.Serialize(*writer);
-  CHECK_EQUAL(data.GetEdgeIdToFeatureId().size(), data.GetEdges().size(), ());
-  return data.GetEdgeIdToFeatureId();
+  return edgeToFeature;
 }
 }  // namespace experimental
 }  // namespace transit


### PR DESCRIPTION
У нас в  transit cross mwm (как и в остальном cross mwm) закреплено соответствие между cross mwm id и feature id, при этом на генерации feature id брался из json (причём в  json feature id кросс-мвмного ребра одинаковый внутри разных мвм, чего кажется быть не должно).

В рантайме feature id нумеруются по порядку в графе (с оффсетом чтобы фичи были фейковыми), а в кросс-мвм к считанному идентификатору прибавляют оффсет. И по факту фича на которую "смотрит" кросс-мвм получатся не та.

В этом реквесте сделан тривиальный фикс в генерацию кросс мвм, который вместо featureId из json использует порядковый номер.
В этом реквесте не сделано исправление feature id в json или выпиливание его оттуда поскольку я не разобралась в коде который его создаёт.

Пока мне кажется что целесообразнее выпилить feature id из json, поскольку нумерация должна быть консистентна с нумерацией при построении графа ОТ в рантайме и логичнее эту консистентность требовать от кода генератора чем от gtfs_converter.

Построение кросс-мвмных маршрутов на от.
Было: креш в А*, если убрать проверку маршрут такой
<img width="1019" alt="Снимок экрана 2021-04-21 в 19 55 11" src="https://user-images.githubusercontent.com/9213190/115668621-fef2c900-a34f-11eb-8bd8-f04840b812f0.png">

Стало: нет креша в А*, маршрут такой
<img width="1019" alt="Снимок экрана 2021-04-21 в 19 54 51" src="https://user-images.githubusercontent.com/9213190/115668553-e682ae80-a34f-11eb-8b41-008027635d66.png">