### PR TITLE
 [transit] Generate trivial shapes.

### DIFF
--- a/transit/world_feed/world_feed.hpp
+++ b/transit/world_feed/world_feed.hpp
@@ -285,7 +285,7 @@ public:
   WorldFeed(IdGenerator & generator, IdGenerator & generatorEdges, ColorPicker & colorPicker,
             feature::CountriesFilesAffiliation & mwmMatcher);
   // Transforms GTFS feed into the global feed.
-  bool SetFeed(gtfs::Feed && feed);
+  bool SetFeed(gtfs::Feed && feed, bool generateTrivialShapes);
 
   // Dumps global feed to |world_feed_path|.
   bool Save(std::string const & worldFeedDir, bool overwrite);
@@ -302,8 +302,9 @@ private:
   bool FillNetworks();
   // Fills routes from GTFS routes data.
   bool FillRoutes();
-  // Fills lines and corresponding shapes from GTFS trips and shapes.
-  bool FillLinesAndShapes();
+  // Fills lines and corresponding shapes from GTFS trips and shapes. Iff |generateTrivialShapes| is
+  // set to true generates trivial shapes for trips without shape id.
+  bool FillLinesAndShapes(bool generateTrivialShapes);
   // Deletes shapes which are sub-shapes and refreshes corresponding links in lines.
   void ModifyLinesAndShapes();
   // Gets service monthday open/closed ranges, weekdays and exceptions in schedule.

--- a/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
+++ b/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
@@ -43,7 +43,7 @@ public:
   {
     gtfs::Feed feed(base::JoinPath(m_testPath, "minimalistic_feed"));
     TEST_EQUAL(feed.read_feed().code, gtfs::ResultCode::OK, ());
-    TEST(m_globalFeed.SetFeed(std::move(feed)), ());
+    TEST(m_globalFeed.SetFeed(std::move(feed), false /* generateTrivialShapes */), ());
 
     TEST_EQUAL(m_globalFeed.m_networks.m_data.size(), 1, ());
     TEST_EQUAL(m_globalFeed.m_routes.m_data.size(), 2, ());
@@ -59,7 +59,7 @@ public:
   {
     gtfs::Feed feed(base::JoinPath(m_testPath, "real_life_feed"));
     TEST_EQUAL(feed.read_feed().code, gtfs::ResultCode::OK, ());
-    TEST(m_globalFeed.SetFeed(std::move(feed)), ());
+    TEST(m_globalFeed.SetFeed(std::move(feed), false /* generateTrivialShapes */), ());
 
     TEST_EQUAL(m_globalFeed.m_networks.m_data.size(), 21, ());
     TEST_EQUAL(m_globalFeed.m_routes.m_data.size(), 87, ());
@@ -78,7 +78,7 @@ public:
   {
     gtfs::Feed feed(base::JoinPath(m_testPath, "feed_with_multiple_shape_projections"));
     TEST_EQUAL(feed.read_feed().code, gtfs::ResultCode::OK, ());
-    TEST(m_globalFeed.SetFeed(std::move(feed)), ());
+    TEST(m_globalFeed.SetFeed(std::move(feed), false /* generateTrivialShapes */), ());
 
     TEST_EQUAL(m_globalFeed.m_networks.m_data.size(), 1, ());
     TEST_EQUAL(m_globalFeed.m_routes.m_data.size(), 1, ());
@@ -96,14 +96,14 @@ public:
     gtfs::Feed feed(base::JoinPath(m_testPath, "feed_with_wrong_stops_order"));
     TEST_EQUAL(feed.read_feed().code, gtfs::ResultCode::OK, ());
     // Feed has wrong stops order (impossible for trip shape) and should be rejected.
-    TEST(!m_globalFeed.SetFeed(std::move(feed)), ());
+    TEST(!m_globalFeed.SetFeed(std::move(feed), false /* generateTrivialShapes */), ());
   }
 
   void ReadFeedWithBackwardOrder()
   {
     gtfs::Feed feed(base::JoinPath(m_testPath, "feed_with_backward_order"));
     TEST_EQUAL(feed.read_feed().code, gtfs::ResultCode::OK, ());
-    TEST(m_globalFeed.SetFeed(std::move(feed)), ());
+    TEST(m_globalFeed.SetFeed(std::move(feed), false /* generateTrivialShapes */), ());
 
     TEST_EQUAL(m_globalFeed.m_networks.m_data.size(), 1, ());
     TEST_EQUAL(m_globalFeed.m_routes.m_data.size(), 1, ());
@@ -124,7 +124,7 @@ public:
   {
     gtfs::Feed feed(base::JoinPath(m_testPath, "feed_long_itinerary"));
     TEST_EQUAL(feed.read_feed().code, gtfs::ResultCode::OK, ());
-    TEST(m_globalFeed.SetFeed(std::move(feed)), ());
+    TEST(m_globalFeed.SetFeed(std::move(feed), false /* generateTrivialShapes */), ());
 
     TEST_EQUAL(m_globalFeed.m_lines.m_data.size(), 1, ());
     TEST_EQUAL(m_globalFeed.m_stops.m_data.size(), 4, ());

--- a/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
+++ b/transit/world_feed/world_feed_integration_tests/world_feed_integration_tests.cpp
@@ -74,6 +74,24 @@ public:
     TEST_EQUAL(m_globalFeed.m_edgesTransfers.m_data.size(), 0, ());
   }
 
+  void ReadRealLifeFeedWithoutShapes()
+  {
+    gtfs::Feed feed(base::JoinPath(m_testPath, "real_life_feed_without_shapes"));
+    TEST_EQUAL(feed.read_feed().code, gtfs::ResultCode::OK, ());
+    TEST(m_globalFeed.SetFeed(std::move(feed), true /* generateTrivialShapes */), ());
+    TEST_EQUAL(m_globalFeed.m_networks.m_data.size(), 21, ());
+    TEST_EQUAL(m_globalFeed.m_routes.m_data.size(), 87, ());
+    // All trips have unique service_id so each line corresponds to some trip.
+    TEST_EQUAL(m_globalFeed.m_lines.m_data.size(), 390, ());
+    TEST_EQUAL(m_globalFeed.m_stops.m_data.size(), 1008, ());
+    // 64 shapes contained in other shapes should be skipped.
+    TEST_EQUAL(m_globalFeed.m_shapes.m_data.size(), 286, ());
+    TEST_EQUAL(m_globalFeed.m_gates.m_data.size(), 0, ());
+    TEST_EQUAL(m_globalFeed.m_transfers.m_data.size(), 0, ());
+    TEST_EQUAL(m_globalFeed.m_edges.m_data.size(), 3977, ());
+    TEST_EQUAL(m_globalFeed.m_edgesTransfers.m_data.size(), 0, ());
+  }
+
   void ReadFeedWithMultipleShapeProjections()
   {
     gtfs::Feed feed(base::JoinPath(m_testPath, "feed_with_multiple_shape_projections"));
@@ -174,6 +192,11 @@ UNIT_CLASS_TEST(WorldFeedIntegrationTests, MinimalisticFeed)
 UNIT_CLASS_TEST(WorldFeedIntegrationTests, RealLifeFeed)
 {
   ReadRealLifeFeed();
+}
+
+UNIT_CLASS_TEST(WorldFeedIntegrationTests, RealLifeFeedWithoutShapes)
+{
+  ReadRealLifeFeedWithoutShapes();
 }
 
 UNIT_CLASS_TEST(WorldFeedIntegrationTests, FeedWithLongItinerary)


### PR DESCRIPTION
В идеале хотелось тест который проверит что фид без  generateTrivialShapes не грузится, а с ним грузится, но для этого надо или иметь два одинаковых фида без шейпов отличающихся agency (и тогда в тесте не будет очевидно что этот один и тот же грузится или не грузится в зависимости от опции), либо завести у  WorldFeed метод который сбрасывает статический  m_agencyHashes и сбрасывать в тестах.  Могу оставить как есть или реализовать один из предложенных выше вариантов.