### PR TITLE
show OSM attribution for longer

### DIFF
--- a/drape_frontend/gui/copyright_label.cpp
+++ b/drape_frontend/gui/copyright_label.cpp
@@ -18,7 +18,7 @@ namespace gui
 {
 namespace
 {
-double const kCopyrightVisibleTime = 2.0f;
+double const kCopyrightVisibleTime = 20.0f;
 double const kCopyrightHideTime = 0.25f;
 
 class CopyrightHandle : public StaticLabelHandle


### PR DESCRIPTION
This is not a sufficient fix of insufficient attribution violating ODbL license,
but it would be a good first step

See https://www.openstreetmap.org/copyright and https://opendatacommons.org/licenses/odbl/1.0/ for details

-----------

note that https://github.com/mapsme/omim/blob/1892903b63f2c85b16ed4966d21fe76aba06b9ba/docs/CLA.md cannot be followed as https://maps.me/cla/ is not working - but for this change there is nothing copyrightable here

-------------

related to #11845 #11203

-------------

due to #14174 I was unable to test this changes, but it is relatively trivial

--------------

Yes, I know that this pull request will be ignored - but I want to demonstrate that I did all what I can do here, going as far as fixing part of the issue for them.